### PR TITLE
Add installer, HTTP auth, and plugin download tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# Wordpress
-eine Wordpress Überwachung Server/client
+# Wordpress Monitoring
+
+Dieses Repository enthält zwei Komponenten, um mehrere WordPress-Installationen zentral zu überwachen:
+
+1. **WP Monitor Client** – ein WordPress-Plugin, das regelmäßig Statusinformationen (Core-, Plugin- & Theme-Versionen, Updates, Benutzerzahlen usw.) sammelt und an einen Server sendet.
+2. **WP Monitor Server** – ein schlankes PHP/MySQL-Skript, das die eingehenden Daten entgegennimmt und in einer Datenbank speichert.
+
+## Schnellstart
+
+### Client (WordPress-Plugin)
+
+1. Kopiere `plugin/wp-monitor-client` in das Verzeichnis `wp-content/plugins/` einer WordPress-Installation.
+2. Aktiviere das Plugin im Backend und öffne **Einstellungen → WP Monitor**.
+3. Trage die URL des Servers sowie einen gültigen API-Schlüssel ein. Optional kannst du eine Installationskennung und das Intervall konfigurieren.
+4. Speichere die Einstellungen. Das Plugin sendet anschließend automatisch Statusberichte im gewünschten Intervall. Eine manuelle Übertragung ist jederzeit möglich.
+
+### Server (API)
+
+1. Kopiere den Ordner `server` auf einen Webserver mit PHP 8.1+ und MySQL/MariaDB.
+2. Rufe `install.php` im Browser auf, um Datenbanktabellen anzulegen, `config.php` zu generieren und HTTP-Auth-Zugangsdaten zu setzen.
+3. Der Server stellt anschließend das Plugin-Paket über `plugin-download.php` bereit (z. B. für `wp plugin install <URL>`).
+4. Stelle sicher, dass `server/api.php` und `server/plugin-download.php` über HTTPS erreichbar sind und per HTTP-Auth geschützt werden.
+
+## Funktionsumfang
+
+* Überwachung von WordPress-Version, Plugins, Themes und verfügbaren Updates.
+* Erfassung von Sicherheitsindikatoren (z. B. automatische Updates, `DISALLOW_FILE_EDIT`).
+* Statistiken zu Benutzern, Kommentaren und Beiträgen.
+* Erweiterbar über WordPress-Hooks und serverseitige Auswertungen.
+
+## Weiterführende Informationen
+
+* [Plugin-Dokumentation](plugin/wp-monitor-client/README.md)
+* [Server-Dokumentation](server/README.md)
+
+Verbesserungen wie Dashboards, zusätzliche Prüfungen (Backups, SSL-Zertifikate etc.) oder Benachrichtigungen können auf Basis dieser Grundstruktur ergänzt werden.

--- a/plugin/wp-monitor-client/README.md
+++ b/plugin/wp-monitor-client/README.md
@@ -1,0 +1,43 @@
+# WP Monitor Client
+
+Dieses WordPress-Plugin sendet regelmäßig Statusinformationen (Core-, Plugin- und Theme-Versionen, verfügbare Updates, Benutzerzahlen u. v. m.) an einen zentralen WP Monitor Server.
+
+## Installation
+
+1. Kopiere den Ordner `wp-monitor-client` in das Verzeichnis `wp-content/plugins/` deiner WordPress-Installation.
+2. Aktiviere das Plugin im WordPress-Backend unter **Plugins → Installierte Plugins**.
+3. Öffne anschließend **Einstellungen → WP Monitor** und trage den URL deines Servers sowie den API-Schlüssel ein.
+4. Wenn der Server per HTTP-Authentifizierung geschützt ist, hinterlege dort auch Benutzername und Passwort.
+5. Optional kannst du eine eigene Installationskennung (z. B. Kundenname oder Standort) vergeben und das Sendeintervall anpassen.
+6. Alternativ kann das Plugin direkt von `plugin-download.php` des Servers installiert werden (z. B. via WP-CLI `wp plugin install https://monitor.example.com/plugin-download.php --activate`).
+
+## Funktionsumfang
+
+* Überträgt folgende Informationen:
+  * WordPress-Version und Serverumgebung (PHP, MySQL, Memory-Limits).
+  * Anzahl verfügbarer Core-, Plugin- und Theme-Updates (inkl. Sicherheitsupdates).
+  * Liste aller Plugins/Themes inkl. Update-Status und Aktivierung.
+  * Kommentar- und Benutzerzahlen sowie veröffentlichte/Entwurf-Posts.
+  * Sicherheitsrelevante Einstellungen (z. B. automatische Updates, `DISALLOW_FILE_EDIT`).
+* Sendet Daten automatisch im gewählten Intervall per WP-Cron.
+* Manuelle Übertragung direkt aus der Einstellungsseite möglich.
+* API-Header (`X-WP-Monitor-*`) helfen dem Server bei der Zuordnung.
+
+## Cron & Debugging
+
+Das Plugin nutzt den WordPress-Cron. Damit automatische Übertragungen funktionieren, muss die Seite regelmäßig aufgerufen werden (oder es wird ein Server-Cronjob eingerichtet, der `wp-cron.php` anstößt).
+
+Bei Problemen findest du in der Browser-Konsole des Adminbereichs und im Fehlerlog deiner WordPress-Instanz weitere Hinweise. Außerdem kannst du die manuelle Übertragung nutzen, um sofortige Rückmeldungen vom Server zu erhalten.
+
+## Erweiterbarkeit
+
+Der gesammelte Datensatz kann über den Filter `wp_monitor_client_snapshot` angepasst werden:
+
+```php
+add_filter( 'wp_monitor_client_snapshot', function ( array $snapshot ) {
+    $snapshot['custom']['health_status'] = get_option( 'health-check-status', 'unknown' );
+    return $snapshot;
+} );
+```
+
+So können projektspezifische Kennzahlen ergänzt werden.

--- a/plugin/wp-monitor-client/includes/class-wp-monitor-client.php
+++ b/plugin/wp-monitor-client/includes/class-wp-monitor-client.php
@@ -1,0 +1,622 @@
+<?php
+/**
+ * Hauptklasse für den WP Monitor Client.
+ *
+ * @package WP_Monitor_Client
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WP_Monitor_Client {
+
+    /**
+     * Cache der Einstellungen.
+     *
+     * @var array|null
+     */
+    private $settings_cache = null;
+
+    /**
+     * Konstruktor – registriert Hooks.
+     */
+    public function __construct() {
+        add_action( 'admin_menu', [ $this, 'register_admin_page' ] );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+        add_action( 'admin_notices', [ $this, 'maybe_render_admin_notice' ] );
+        add_action( WP_MONITOR_CLIENT_CRON_HOOK, [ $this, 'send_snapshot' ] );
+        add_action( 'init', [ $this, 'maybe_schedule_cron' ] );
+        add_filter( 'cron_schedules', [ $this, 'register_custom_interval' ] );
+    }
+
+    /**
+     * Wird bei Aktivierung ausgeführt.
+     */
+    public static function activate() {
+        $instance = wp_monitor_client();
+        $instance->settings_cache = null;
+        $instance->maybe_schedule_cron( true );
+    }
+
+    /**
+     * Wird bei Deaktivierung ausgeführt.
+     */
+    public static function deactivate() {
+        wp_clear_scheduled_hook( WP_MONITOR_CLIENT_CRON_HOOK );
+    }
+
+    /**
+     * Registriert den Menüeintrag in den Einstellungen.
+     */
+    public function register_admin_page() {
+        add_options_page(
+            __( 'WP Monitor Client', 'wp-monitor-client' ),
+            __( 'WP Monitor', 'wp-monitor-client' ),
+            'manage_options',
+            'wp-monitor-client',
+            [ $this, 'render_settings_page' ]
+        );
+    }
+
+    /**
+     * Registriert die Einstellungen.
+     */
+    public function register_settings() {
+        register_setting( 'wp_monitor_client', WP_MONITOR_CLIENT_OPTION, [ $this, 'sanitize_settings' ] );
+
+        add_settings_section(
+            'wp_monitor_client_connection',
+            __( 'Verbindungseinstellungen', 'wp-monitor-client' ),
+            '__return_false',
+            'wp-monitor-client'
+        );
+
+        add_settings_field(
+            'endpoint',
+            __( 'Server-Endpunkt', 'wp-monitor-client' ),
+            [ $this, 'render_endpoint_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_connection'
+        );
+
+        add_settings_field(
+            'api_key',
+            __( 'API-Schlüssel', 'wp-monitor-client' ),
+            [ $this, 'render_api_key_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_connection'
+        );
+
+        add_settings_field(
+            'http_username',
+            __( 'HTTP-Benutzername', 'wp-monitor-client' ),
+            [ $this, 'render_http_username_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_connection'
+        );
+
+        add_settings_field(
+            'http_password',
+            __( 'HTTP-Passwort', 'wp-monitor-client' ),
+            [ $this, 'render_http_password_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_connection'
+        );
+
+        add_settings_field(
+            'site_token',
+            __( 'Installationskennung', 'wp-monitor-client' ),
+            [ $this, 'render_site_token_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_connection'
+        );
+
+        add_settings_section(
+            'wp_monitor_client_schedule',
+            __( 'Übertragung', 'wp-monitor-client' ),
+            '__return_false',
+            'wp-monitor-client'
+        );
+
+        add_settings_field(
+            'interval',
+            __( 'Intervall (Stunden)', 'wp-monitor-client' ),
+            [ $this, 'render_interval_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_schedule'
+        );
+    }
+
+    /**
+     * Validiert die Einstellungen.
+     */
+    public function sanitize_settings( $settings ) {
+        $defaults = [
+            'endpoint'    => '',
+            'api_key'     => '',
+            'http_username' => '',
+            'http_password' => '',
+            'site_token'  => '',
+            'interval'    => 6,
+        ];
+
+        $existing_settings = $this->get_settings();
+        $raw_settings      = isset( $_POST[ WP_MONITOR_CLIENT_OPTION ] ) ? (array) wp_unslash( $_POST[ WP_MONITOR_CLIENT_OPTION ] ) : [];
+
+        $settings = wp_parse_args( $settings, $defaults );
+
+        $settings['endpoint']   = esc_url_raw( trim( $settings['endpoint'] ) );
+        $settings['api_key']    = sanitize_text_field( $settings['api_key'] );
+        $settings['http_username'] = sanitize_text_field( $settings['http_username'] );
+        $settings['site_token'] = sanitize_text_field( $settings['site_token'] );
+        $settings['interval']   = max( 1, absint( $settings['interval'] ) );
+
+        $submitted_password = isset( $settings['http_password'] ) ? (string) $settings['http_password'] : '';
+        if ( ! empty( $raw_settings['http_password_clear'] ) ) {
+            $settings['http_password'] = '';
+        } elseif ( '' === $submitted_password ) {
+            $settings['http_password'] = $existing_settings['http_password'] ?? '';
+        } else {
+            $settings['http_password'] = sanitize_text_field( $submitted_password );
+        }
+
+        unset( $settings['http_password_clear'] );
+
+        $this->settings_cache = $settings;
+        $this->maybe_reschedule_cron();
+
+        return $settings;
+    }
+
+    /**
+     * Rendert das Einstellungsformular.
+     */
+    public function render_settings_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $settings = $this->get_settings();
+
+        if ( isset( $_POST['wp_monitor_client_send_now'] ) && check_admin_referer( 'wp_monitor_client_send_now' ) ) {
+            $result = $this->send_snapshot();
+            $this->store_admin_notice( $result );
+            wp_safe_redirect( add_query_arg( 'settings-updated', 'true', menu_page_url( 'wp-monitor-client', false ) ) );
+            exit;
+        }
+
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'WP Monitor Client', 'wp-monitor-client' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields( 'wp_monitor_client' );
+                do_settings_sections( 'wp-monitor-client' );
+                submit_button();
+                ?>
+            </form>
+
+            <hr />
+
+            <h2><?php esc_html_e( 'Manuelle Übertragung', 'wp-monitor-client' ); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field( 'wp_monitor_client_send_now' ); ?>
+                <p><?php esc_html_e( 'Sendet sofort einen aktuellen Statusbericht an den Überwachungsserver.', 'wp-monitor-client' ); ?></p>
+                <?php submit_button( __( 'Jetzt senden', 'wp-monitor-client' ), 'secondary', 'wp_monitor_client_send_now' ); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Feld: Endpunkt.
+     */
+    public function render_endpoint_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="url" class="regular-text code" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[endpoint]" value="<?php echo esc_attr( $settings['endpoint'] ); ?>" placeholder="https://monitor.example.com/api.php" />
+        <?php
+    }
+
+    /**
+     * Feld: API-Key.
+     */
+    public function render_api_key_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="text" class="regular-text" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[api_key]" value="<?php echo esc_attr( $settings['api_key'] ); ?>" />
+        <p class="description"><?php esc_html_e( 'Der auf dem Server konfigurierte API-Schlüssel.', 'wp-monitor-client' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Feld: HTTP-Benutzername.
+     */
+    public function render_http_username_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="text" class="regular-text" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[http_username]" value="<?php echo esc_attr( $settings['http_username'] ); ?>" autocomplete="username" />
+        <p class="description"><?php esc_html_e( 'Optionaler Benutzername für HTTP-Basic-Auth auf dem Server.', 'wp-monitor-client' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Feld: HTTP-Passwort.
+     */
+    public function render_http_password_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="password" class="regular-text" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[http_password]" value="" autocomplete="new-password" />
+        <?php if ( ! empty( $settings['http_password'] ) ) : ?>
+            <p class="description"><?php esc_html_e( 'Leer lassen, um das gespeicherte Passwort zu behalten, oder ein neues Passwort eingeben.', 'wp-monitor-client' ); ?></p>
+            <label>
+                <input type="checkbox" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[http_password_clear]" value="1" />
+                <?php esc_html_e( 'Gespeichertes Passwort löschen', 'wp-monitor-client' ); ?>
+            </label>
+        <?php else : ?>
+            <p class="description"><?php esc_html_e( 'Passwort für HTTP-Basic-Auth auf dem Server.', 'wp-monitor-client' ); ?></p>
+        <?php endif; ?>
+        <?php
+    }
+
+    /**
+     * Feld: Site Token.
+     */
+    public function render_site_token_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="text" class="regular-text" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[site_token]" value="<?php echo esc_attr( $settings['site_token'] ); ?>" />
+        <p class="description"><?php esc_html_e( 'Individuelle Kennung dieser Installation (optional).', 'wp-monitor-client' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Feld: Intervall.
+     */
+    public function render_interval_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="number" min="1" class="small-text" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[interval]" value="<?php echo esc_attr( $settings['interval'] ); ?>" />
+        <p class="description"><?php esc_html_e( 'In welchem Abstand (in Stunden) Statusdaten versendet werden sollen.', 'wp-monitor-client' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Gibt die Einstellungen zurück.
+     */
+    public function get_settings() {
+        if ( null !== $this->settings_cache ) {
+            return $this->settings_cache;
+        }
+
+        $defaults = [
+            'endpoint'   => '',
+            'api_key'    => '',
+            'site_token' => '',
+            'interval'   => 6,
+        ];
+
+        $this->settings_cache = wp_parse_args( get_option( WP_MONITOR_CLIENT_OPTION, [] ), $defaults );
+
+        return $this->settings_cache;
+    }
+
+    /**
+     * Plant den Cronjob, falls nötig.
+     *
+     * @param bool $force_schedule Erzwingt eine Neuplanung.
+     */
+    public function maybe_schedule_cron( $force_schedule = false ) {
+        if ( $force_schedule ) {
+            $timestamp = wp_next_scheduled( WP_MONITOR_CLIENT_CRON_HOOK );
+            if ( $timestamp ) {
+                wp_unschedule_event( $timestamp, WP_MONITOR_CLIENT_CRON_HOOK );
+            }
+        }
+
+        if ( ! wp_next_scheduled( WP_MONITOR_CLIENT_CRON_HOOK ) ) {
+            $this->schedule_event();
+        }
+    }
+
+    /**
+     * Plant den Cronjob neu, falls sich das Intervall geändert hat.
+     */
+    private function maybe_reschedule_cron() {
+        $timestamp = wp_next_scheduled( WP_MONITOR_CLIENT_CRON_HOOK );
+        if ( $timestamp ) {
+            wp_unschedule_event( $timestamp, WP_MONITOR_CLIENT_CRON_HOOK );
+        }
+
+        $this->schedule_event();
+    }
+
+    /**
+     * Plant das Cron-Event.
+     */
+    private function schedule_event() {
+        wp_schedule_event( time() + MINUTE_IN_SECONDS, 'wp_monitor_client_interval', WP_MONITOR_CLIENT_CRON_HOOK );
+    }
+
+    /**
+     * Registriert das individuelle Cron-Intervall.
+     */
+    public function register_custom_interval( $schedules ) {
+        $settings = $this->get_settings();
+        $interval = max( 1, absint( $settings['interval'] ) );
+
+        $schedules['wp_monitor_client_interval'] = [
+            'interval' => HOUR_IN_SECONDS * $interval,
+            'display'  => sprintf( _n( 'Alle %d Stunde', 'Alle %d Stunden', $interval, 'wp-monitor-client' ), $interval ),
+        ];
+
+        return $schedules;
+    }
+
+    /**
+     * Sendet die gesammelten Daten an den Server.
+     */
+    public function send_snapshot() {
+        $settings = $this->get_settings();
+
+        if ( empty( $settings['endpoint'] ) || empty( $settings['api_key'] ) ) {
+            return [
+                'success' => false,
+                'message' => __( 'Es ist kein Endpunkt oder API-Schlüssel konfiguriert.', 'wp-monitor-client' ),
+            ];
+        }
+
+        $payload = apply_filters( 'wp_monitor_client_snapshot', $this->collect_snapshot() );
+
+        $headers = [
+            'Content-Type'      => 'application/json',
+            'X-WP-Monitor-Key'  => $settings['api_key'],
+            'X-WP-Monitor-Site' => $settings['site_token'] ? $settings['site_token'] : home_url(),
+            'X-WP-Monitor-Version' => WP_MONITOR_CLIENT_VERSION,
+        ];
+
+        if ( ! empty( $settings['http_username'] ) && ! empty( $settings['http_password'] ) ) {
+            $headers['Authorization'] = 'Basic ' . base64_encode( $settings['http_username'] . ':' . $settings['http_password'] );
+        }
+
+        $response = wp_remote_post(
+            $settings['endpoint'],
+            [
+                'timeout' => 20,
+                'headers' => $headers,
+                'body'    => wp_json_encode( $payload ),
+            ]
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return [
+                'success' => false,
+                'message' => $response->get_error_message(),
+            ];
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        $body = wp_remote_retrieve_body( $response );
+
+        if ( $code >= 200 && $code < 300 ) {
+            return [
+                'success' => true,
+                'message' => __( 'Status erfolgreich übertragen.', 'wp-monitor-client' ),
+                'details' => $body,
+            ];
+        }
+
+        return [
+            'success' => false,
+            'message' => sprintf( __( 'Fehlerhafte Antwort vom Server (%d).', 'wp-monitor-client' ), $code ),
+            'details' => $body,
+        ];
+    }
+
+    /**
+     * Sammelt Statusinformationen der WordPress-Installation.
+     */
+    public function collect_snapshot() {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+        global $wpdb;
+
+        $settings      = $this->get_settings();
+        $plugins        = get_plugins();
+        $active_plugins = get_option( 'active_plugins', [] );
+        $plugin_updates = get_site_transient( 'update_plugins' );
+        $plugin_updates = ( is_object( $plugin_updates ) && isset( $plugin_updates->response ) ) ? (array) $plugin_updates->response : [];
+
+        $themes        = wp_get_themes();
+        $theme_updates = get_site_transient( 'update_themes' );
+        $theme_updates = ( is_object( $theme_updates ) && isset( $theme_updates->response ) ) ? (array) $theme_updates->response : [];
+        $current_theme = wp_get_theme();
+
+        $core_updates = get_site_transient( 'update_core' );
+        $update_data  = wp_get_update_data();
+        $core_channels_data = ( is_object( $core_updates ) && isset( $core_updates->updates ) ) ? $core_updates->updates : $core_updates;
+        $comment_counts = wp_count_comments();
+        $user_counts    = count_users();
+        $post_counts    = wp_count_posts();
+        $multisite      = is_multisite();
+
+        $plugin_payload = [];
+        foreach ( $plugins as $file => $data ) {
+            $update_version = '';
+            $has_update     = false;
+
+            if ( isset( $plugin_updates[ $file ] ) ) {
+                $has_update = true;
+                $update     = $plugin_updates[ $file ];
+
+                if ( is_object( $update ) && isset( $update->new_version ) ) {
+                    $update_version = $update->new_version;
+                } elseif ( is_array( $update ) && isset( $update['new_version'] ) ) {
+                    $update_version = $update['new_version'];
+                }
+            }
+
+            $plugin_payload[] = [
+                'file'           => $file,
+                'name'           => $data['Name'],
+                'version'        => $data['Version'],
+                'is_active'      => in_array( $file, $active_plugins, true ),
+                'has_update'     => $has_update,
+                'update_version' => $update_version,
+                'author'         => $data['AuthorName'] ?? '',
+                'plugin_uri'     => $data['PluginURI'] ?? '',
+            ];
+        }
+
+        $theme_payload = [];
+        foreach ( $themes as $stylesheet => $theme ) {
+            $update_version = '';
+            $has_update     = false;
+
+            if ( isset( $theme_updates[ $stylesheet ] ) ) {
+                $has_update = true;
+                $update     = $theme_updates[ $stylesheet ];
+
+                if ( is_array( $update ) && isset( $update['new_version'] ) ) {
+                    $update_version = $update['new_version'];
+                } elseif ( is_object( $update ) && isset( $update->new_version ) ) {
+                    $update_version = $update->new_version;
+                }
+            }
+
+            $theme_payload[] = [
+                'stylesheet'     => $stylesheet,
+                'name'           => $theme->get( 'Name' ),
+                'version'        => $theme->get( 'Version' ),
+                'is_active'      => $current_theme->get_stylesheet() === $stylesheet,
+                'has_update'     => $has_update,
+                'update_version' => $update_version,
+                'author'         => $theme->get( 'Author' ),
+            ];
+        }
+
+        $core_security_updates = isset( $update_data['counts']['security'] ) ? (int) $update_data['counts']['security'] : 0;
+        $core_total_updates    = isset( $update_data['counts']['total'] ) ? (int) $update_data['counts']['total'] : 0;
+        $plugin_update_count   = isset( $update_data['counts']['plugins'] ) ? (int) $update_data['counts']['plugins'] : 0;
+        $theme_update_count    = isset( $update_data['counts']['themes'] ) ? (int) $update_data['counts']['themes'] : 0;
+        $translation_updates   = isset( $update_data['counts']['translations'] ) ? (int) $update_data['counts']['translations'] : 0;
+
+        $php_version   = phpversion();
+        $mysql_version = method_exists( $wpdb, 'db_version' ) ? $wpdb->db_version() : '';
+        $core_last_checked = ( is_object( $core_updates ) && isset( $core_updates->last_checked ) ) ? (int) $core_updates->last_checked : 0;
+
+        $automatic_updates = function_exists( 'wp_is_auto_update_enabled_for_type' ) ? (bool) wp_is_auto_update_enabled_for_type( 'core' ) : false;
+
+        $snapshot = [
+            'site' => [
+                'url'        => home_url(),
+                'name'       => get_bloginfo( 'name' ),
+                'language'   => get_bloginfo( 'language' ),
+                'timezone'   => wp_timezone_string(),
+                'token'      => $settings['site_token'],
+            ],
+            'environment' => [
+                'php_version'         => $php_version,
+                'mysql_version'       => $mysql_version,
+                'wp_version'          => get_bloginfo( 'version' ),
+                'is_multisite'        => $multisite,
+                'php_memory_limit'    => ini_get( 'memory_limit' ),
+                'php_max_execution'   => ini_get( 'max_execution_time' ),
+                'wp_debug'            => defined( 'WP_DEBUG' ) ? WP_DEBUG : false,
+            ],
+            'updates' => [
+                'core_available'   => $core_total_updates,
+                'core_security'    => $core_security_updates,
+                'plugins'          => $plugin_update_count,
+                'themes'           => $theme_update_count,
+                'translations'     => $translation_updates,
+                'core_channels'    => $this->normalize_core_updates( $core_channels_data ),
+            ],
+            'plugins' => $plugin_payload,
+            'themes'  => $theme_payload,
+            'counts'  => [
+                'pending_comments' => (int) $comment_counts->moderated,
+                'spam_comments'    => (int) $comment_counts->spam,
+                'registered_users' => (int) $user_counts['total_users'],
+                'draft_posts'      => (int) $post_counts->draft,
+                'published_posts'  => (int) $post_counts->publish,
+            ],
+            'security' => [
+                'last_core_update_check' => $core_last_checked,
+                'automatic_updates'      => $automatic_updates,
+                'force_ssl_admin'        => function_exists( 'force_ssl_admin' ) ? (bool) force_ssl_admin() : false,
+                'disallow_file_edit'     => defined( 'DISALLOW_FILE_EDIT' ) ? (bool) DISALLOW_FILE_EDIT : false,
+                'disallow_file_mods'     => defined( 'DISALLOW_FILE_MODS' ) ? (bool) DISALLOW_FILE_MODS : false,
+            ],
+            'generated_at' => current_time( 'mysql' ),
+        ];
+
+        return $snapshot;
+    }
+
+    /**
+     * Normalisiert die Core-Update-Informationen für den Export.
+     */
+    private function normalize_core_updates( $core_updates ) {
+        if ( ! is_array( $core_updates ) && ! is_object( $core_updates ) ) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ( (array) $core_updates as $update ) {
+            if ( ! is_object( $update ) || empty( $update->version ) ) {
+                continue;
+            }
+
+            $normalized[] = [
+                'version'     => $update->version,
+                'php_version' => $update->php_version ?? '',
+                'packages'    => [
+                    'full'    => $update->package ?? '',
+                    'partial' => $update->partial_package ?? '',
+                ],
+                'dismissed'   => ! empty( $update->dismissed ),
+                'current'     => ! empty( $update->current ),
+                'locale'      => $update->locale ?? '',
+            ];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Speichert einen Hinweis für den Admin-Bereich.
+     */
+    private function store_admin_notice( $result ) {
+        set_transient( WP_MONITOR_CLIENT_TRANSIENT, $result, MINUTE_IN_SECONDS * 10 );
+    }
+
+    /**
+     * Gibt gespeicherte Hinweise aus.
+     */
+    public function maybe_render_admin_notice() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $notice = get_transient( WP_MONITOR_CLIENT_TRANSIENT );
+
+        if ( ! $notice ) {
+            return;
+        }
+
+        delete_transient( WP_MONITOR_CLIENT_TRANSIENT );
+
+        $class = $notice['success'] ? 'updated' : 'error';
+        ?>
+        <div class="notice <?php echo esc_attr( $class ); ?> is-dismissible">
+            <p><strong><?php echo esc_html( $notice['message'] ); ?></strong></p>
+            <?php if ( ! empty( $notice['details'] ) ) : ?>
+                <p><code><?php echo esc_html( wp_trim_words( wp_strip_all_tags( $notice['details'] ), 40, '…' ) ); ?></code></p>
+            <?php endif; ?>
+        </div>
+        <?php
+    }
+}

--- a/plugin/wp-monitor-client/wp-monitor-client.php
+++ b/plugin/wp-monitor-client/wp-monitor-client.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Plugin Name:       WP Monitor Client
+ * Plugin URI:        https://example.com/
+ * Description:       Sendet Zustandsdaten der Installation an einen zentralen Überwachungsserver.
+ * Version:           1.0.0
+ * Author:            WP Monitoring
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       wp-monitor-client
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+const WP_MONITOR_CLIENT_VERSION      = '1.0.0';
+const WP_MONITOR_CLIENT_OPTION       = 'wp_monitor_client_settings';
+const WP_MONITOR_CLIENT_CRON_HOOK    = 'wp_monitor_client_send_snapshot';
+const WP_MONITOR_CLIENT_TRANSIENT    = 'wp_monitor_client_admin_notice';
+
+require_once __DIR__ . '/includes/class-wp-monitor-client.php';
+
+function wp_monitor_client() {
+    static $instance = null;
+
+    if ( null === $instance ) {
+        $instance = new WP_Monitor_Client();
+    }
+
+    return $instance;
+}
+
+wp_monitor_client();
+
+register_activation_hook( __FILE__, [ 'WP_Monitor_Client', 'activate' ] );
+register_deactivation_hook( __FILE__, [ 'WP_Monitor_Client', 'deactivate' ] );

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,111 @@
+# WP Monitor Server
+
+Dieses Verzeichnis enthält ein schlankes PHP-Skript, das Statusdaten aus dem „WP Monitor Client“-Plugin entgegennimmt und in einer MySQL-Datenbank speichert. Es ist als Ausgangspunkt gedacht und kann nach Bedarf erweitert werden (z. B. um ein Dashboard oder Benachrichtigungen).
+
+## Installation
+
+1. Lade den Ordner `server` auf deinen Webserver hoch.
+2. Rufe `install.php` im Browser auf (z. B. `https://monitor.example.com/install.php`).
+3. Trage die Datenbankzugangsdaten, einen API-Schlüssel (optional) sowie Zugangsdaten für die HTTP-Authentifizierung ein.
+4. Die Installation legt die Tabellen an, erstellt `config.php` und zeigt dir den generierten API-Schlüssel an.
+5. Nach erfolgreicher Einrichtung kannst du das Plugin direkt über `plugin-download.php` herunterladen.
+6. Entferne oder schütze `install.php` zusätzlich, sobald die Installation abgeschlossen ist.
+
+## Konfiguration
+
+```php
+return [
+    'db' => [
+        'host'     => '127.0.0.1',
+        'port'     => 3306,
+        'name'     => 'wp_monitor',
+        'user'     => 'wp_monitor',
+        'password' => 'geheimes-passwort',
+        'charset'  => 'utf8mb4',
+    ],
+    'api_keys' => [
+        'mein-api-schluessel' => 'Kundenname oder Standort',
+    ],
+    'http_auth' => [
+        'realm'         => 'WP Monitor',
+        'username'      => 'monitor',
+        'password_hash' => '$2y$10$....',
+    ],
+];
+```
+
+* Jeder API-Schlüssel ordnet eingehende Daten einer Gruppe zu (z. B. Kundenname oder Standort).
+* Weitere Installationen können denselben Schlüssel teilen, um sie logisch zusammenzufassen.
+* Die Basic-Auth-Zugangsdaten sichern sowohl die API als auch den direkten Plugin-Download (`plugin-download.php`).
+
+## Erwartetes Datenformat
+
+Das Plugin sendet JSON-Daten mit u. a. folgenden Feldern:
+
+```json
+{
+  "site": {
+    "url": "https://example.com",
+    "name": "Beispielseite",
+    "language": "de-DE",
+    "token": "installation-123"
+  },
+  "environment": {
+    "wp_version": "6.4.3",
+    "php_version": "8.2.7",
+    "mysql_version": "10.11.2-MariaDB",
+    "php_memory_limit": "256M"
+  },
+  "updates": {
+    "core_available": 1,
+    "plugins": 2,
+    "themes": 0
+  },
+  "counts": {
+    "pending_comments": 5,
+    "registered_users": 47
+  },
+  "plugins": [
+    {
+      "file": "akismet/akismet.php",
+      "name": "Akismet",
+      "version": "5.3",
+      "is_active": true,
+      "has_update": false
+    }
+  ],
+  "themes": [],
+  "generated_at": "2024-04-30 13:37:00"
+}
+```
+
+Alle empfangenen Daten werden zusätzlich als JSON-Blob in der Tabelle `installation_checks.payload` gespeichert, damit später neue Auswertungen möglich sind.
+
+## Antwort des Servers
+
+Bei Erfolg gibt `api.php` eine JSON-Antwort aus:
+
+```json
+{
+  "status": "ok",
+  "installation_id": 1,
+  "check_id": 42,
+  "received_at": "2024-04-30T11:37:22+00:00"
+}
+```
+
+Schlägt etwas fehl, erhält der Client eine passende Fehlermeldung und einen HTTP-Statuscode (z. B. `401 Unauthorized` oder `500 Internal Server Error`).
+
+## Sicherheitshinweise
+
+* Verwende ausschließlich HTTPS, damit API-Schlüssel und Daten geschützt sind.
+* Vergib starke, eindeutige API-Schlüssel und ändere sie regelmäßig.
+* Bewahre die Zugangsdaten für die HTTP-Authentifizierung sicher auf und ändere sie bei Bedarf.
+* Beschränke den Zugriff auf `api.php` zusätzlich (z. B. per Firewall), falls der Endpunkt nicht öffentlich erreichbar sein soll.
+* Überwache die Größe der `payload`-Spalte und rotiere alte Datensätze, um die Datenbank schlank zu halten.
+
+## Erweiterungsideen
+
+* E-Mail- oder Slack-Benachrichtigungen, wenn Sicherheitsupdates verfügbar sind.
+* Dashboard zur Visualisierung der Daten (z. B. mit Laravel, Symfony oder einem JavaScript-Frontend).
+* Zusätzliche Prüfungen wie SSL-Zertifikatslaufzeit, verfügbare Backups oder Server-Ressourcenauslastung.

--- a/server/api.php
+++ b/server/api.php
@@ -1,0 +1,226 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/auth.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$configFile = __DIR__ . '/config.php';
+if ( ! file_exists( $configFile ) ) {
+    http_response_code( 500 );
+    echo json_encode( [ 'error' => 'Server configuration missing.' ] );
+    exit;
+}
+
+$config = require $configFile;
+
+wp_monitor_require_basic_auth( $config, 'json' );
+
+if ( $_SERVER['REQUEST_METHOD'] !== 'POST' ) {
+    http_response_code( 405 );
+    header( 'Allow: POST' );
+    echo json_encode( [ 'error' => 'Method not allowed.' ] );
+    exit;
+}
+
+$apiKey = $_SERVER['HTTP_X_WP_MONITOR_KEY'] ?? '';
+if ( empty( $apiKey ) || ! isset( $config['api_keys'][ $apiKey ] ) ) {
+    http_response_code( 401 );
+    echo json_encode( [ 'error' => 'Unauthorized.' ] );
+    exit;
+}
+
+$group = $config['api_keys'][ $apiKey ];
+$siteIdentifier = $_SERVER['HTTP_X_WP_MONITOR_SITE'] ?? '';
+$siteIdentifier = trim( $siteIdentifier );
+
+$rawBody = file_get_contents( 'php://input' );
+$data    = json_decode( $rawBody, true );
+
+if ( json_last_error() !== JSON_ERROR_NONE || ! is_array( $data ) ) {
+    http_response_code( 400 );
+    echo json_encode( [ 'error' => 'Invalid JSON payload.' ] );
+    exit;
+}
+
+try {
+    $dsn = sprintf(
+        'mysql:host=%s;port=%d;dbname=%s;charset=%s',
+        $config['db']['host'],
+        $config['db']['port'],
+        $config['db']['name'],
+        $config['db']['charset'] ?? 'utf8mb4'
+    );
+
+    $pdo = new PDO( $dsn, $config['db']['user'], $config['db']['password'], [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ] );
+} catch ( PDOException $exception ) {
+    http_response_code( 500 );
+    echo json_encode( [ 'error' => 'Database connection failed.', 'message' => $exception->getMessage() ] );
+    exit;
+}
+
+$siteData      = $data['site'] ?? [];
+$environment   = $data['environment'] ?? [];
+$updates       = $data['updates'] ?? [];
+$counts        = $data['counts'] ?? [];
+$security      = $data['security'] ?? [];
+$plugins       = $data['plugins'] ?? [];
+$themes        = $data['themes'] ?? [];
+$generatedAt   = $data['generated_at'] ?? gmdate( 'Y-m-d H:i:s' );
+$siteUrl       = isset( $siteData['url'] ) ? trim( (string) $siteData['url'] ) : '';
+$siteName      = isset( $siteData['name'] ) ? trim( (string) $siteData['name'] ) : '';
+$siteToken     = $siteIdentifier ?: ( isset( $siteData['token'] ) ? (string) $siteData['token'] : '' );
+$siteToken     = $siteToken ?: hash( 'sha256', $siteUrl ?: uniqid( 'site_', true ) );
+
+if ( empty( $siteUrl ) ) {
+    http_response_code( 400 );
+    echo json_encode( [ 'error' => 'Site URL missing in payload.' ] );
+    exit;
+}
+
+$pdo->beginTransaction();
+
+try {
+    $installationId = null;
+
+    $selectStmt = $pdo->prepare( 'SELECT id FROM installations WHERE site_token = :token LIMIT 1' );
+    $selectStmt->execute( [ ':token' => $siteToken ] );
+    $existing = $selectStmt->fetch();
+
+    $now = ( new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d H:i:s' );
+
+    if ( $existing ) {
+        $installationId = (int) $existing['id'];
+        $updateStmt     = $pdo->prepare( 'UPDATE installations SET site_url = :url, site_name = :name, site_group = :grp, last_seen = :seen WHERE id = :id' );
+        $updateStmt->execute( [
+            ':url'  => $siteUrl,
+            ':name' => $siteName,
+            ':grp'  => $group,
+            ':seen' => $now,
+            ':id'   => $installationId,
+        ] );
+    } else {
+        $insertStmt = $pdo->prepare( 'INSERT INTO installations (site_token, site_url, site_name, site_group, created_at, last_seen) VALUES (:token, :url, :name, :grp, :created, :seen)' );
+        $insertStmt->execute( [
+            ':token'   => $siteToken,
+            ':url'     => $siteUrl,
+            ':name'    => $siteName,
+            ':grp'     => $group,
+            ':created' => $now,
+            ':seen'    => $now,
+        ] );
+        $installationId = (int) $pdo->lastInsertId();
+    }
+
+    $insertCheck = $pdo->prepare(
+        'INSERT INTO installation_checks (
+            installation_id,
+            checked_at,
+            wp_version,
+            php_version,
+            mysql_version,
+            core_updates,
+            core_security_updates,
+            plugin_updates,
+            theme_updates,
+            translation_updates,
+            pending_comments,
+            spam_comments,
+            registered_users,
+            draft_posts,
+            published_posts,
+            payload
+        ) VALUES (
+            :installation_id,
+            :checked_at,
+            :wp_version,
+            :php_version,
+            :mysql_version,
+            :core_updates,
+            :core_security_updates,
+            :plugin_updates,
+            :theme_updates,
+            :translation_updates,
+            :pending_comments,
+            :spam_comments,
+            :registered_users,
+            :draft_posts,
+            :published_posts,
+            :payload
+        )'
+    );
+
+    $insertCheck->execute( [
+        ':installation_id'       => $installationId,
+        ':checked_at'            => $generatedAt,
+        ':wp_version'            => (string) ( $environment['wp_version'] ?? '' ),
+        ':php_version'           => (string) ( $environment['php_version'] ?? '' ),
+        ':mysql_version'         => (string) ( $environment['mysql_version'] ?? '' ),
+        ':core_updates'          => (int) ( $updates['core_available'] ?? 0 ),
+        ':core_security_updates' => (int) ( $updates['core_security'] ?? 0 ),
+        ':plugin_updates'        => (int) ( $updates['plugins'] ?? 0 ),
+        ':theme_updates'         => (int) ( $updates['themes'] ?? 0 ),
+        ':translation_updates'   => (int) ( $updates['translations'] ?? 0 ),
+        ':pending_comments'      => (int) ( $counts['pending_comments'] ?? 0 ),
+        ':spam_comments'         => (int) ( $counts['spam_comments'] ?? 0 ),
+        ':registered_users'      => (int) ( $counts['registered_users'] ?? 0 ),
+        ':draft_posts'           => (int) ( $counts['draft_posts'] ?? 0 ),
+        ':published_posts'       => (int) ( $counts['published_posts'] ?? 0 ),
+        ':payload'               => json_encode( $data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+    ] );
+
+    $checkId = (int) $pdo->lastInsertId();
+
+    $pluginStmt = $pdo->prepare( 'INSERT INTO installation_plugins (check_id, plugin_file, plugin_name, plugin_version, is_active, has_update, update_version) VALUES (:check_id, :file, :name, :version, :is_active, :has_update, :update_version)' );
+    foreach ( $plugins as $plugin ) {
+        $pluginStmt->execute( [
+            ':check_id'      => $checkId,
+            ':file'          => substr( (string) ( $plugin['file'] ?? '' ), 0, 255 ),
+            ':name'          => substr( (string) ( $plugin['name'] ?? '' ), 0, 190 ),
+            ':version'       => substr( (string) ( $plugin['version'] ?? '' ), 0, 50 ),
+            ':is_active'     => ! empty( $plugin['is_active'] ) ? 1 : 0,
+            ':has_update'    => ! empty( $plugin['has_update'] ) ? 1 : 0,
+            ':update_version'=> substr( (string) ( $plugin['update_version'] ?? '' ), 0, 50 ),
+        ] );
+    }
+
+    $themeStmt = $pdo->prepare( 'INSERT INTO installation_themes (check_id, theme_stylesheet, theme_name, theme_version, is_active, has_update, update_version) VALUES (:check_id, :stylesheet, :name, :version, :is_active, :has_update, :update_version)' );
+    foreach ( $themes as $theme ) {
+        $themeStmt->execute( [
+            ':check_id'      => $checkId,
+            ':stylesheet'    => substr( (string) ( $theme['stylesheet'] ?? '' ), 0, 191 ),
+            ':name'          => substr( (string) ( $theme['name'] ?? '' ), 0, 190 ),
+            ':version'       => substr( (string) ( $theme['version'] ?? '' ), 0, 50 ),
+            ':is_active'     => ! empty( $theme['is_active'] ) ? 1 : 0,
+            ':has_update'    => ! empty( $theme['has_update'] ) ? 1 : 0,
+            ':update_version'=> substr( (string) ( $theme['update_version'] ?? '' ), 0, 50 ),
+        ] );
+    }
+
+    $securityStmt = $pdo->prepare( 'INSERT INTO installation_security (check_id, automatic_updates, force_ssl_admin, disallow_file_edit, disallow_file_mods, core_last_check) VALUES (:check_id, :automatic_updates, :force_ssl_admin, :disallow_file_edit, :disallow_file_mods, :core_last_check)' );
+    $securityStmt->execute( [
+        ':check_id'           => $checkId,
+        ':automatic_updates'  => ! empty( $security['automatic_updates'] ) ? 1 : 0,
+        ':force_ssl_admin'    => ! empty( $security['force_ssl_admin'] ) ? 1 : 0,
+        ':disallow_file_edit' => ! empty( $security['disallow_file_edit'] ) ? 1 : 0,
+        ':disallow_file_mods' => ! empty( $security['disallow_file_mods'] ) ? 1 : 0,
+        ':core_last_check'    => (int) ( $security['last_core_update_check'] ?? 0 ),
+    ] );
+
+    $pdo->commit();
+} catch ( Throwable $throwable ) {
+    $pdo->rollBack();
+    http_response_code( 500 );
+    echo json_encode( [ 'error' => 'Failed to persist payload.', 'message' => $throwable->getMessage() ] );
+    exit;
+}
+
+echo json_encode( [
+    'status'           => 'ok',
+    'installation_id'  => $installationId,
+    'check_id'         => $checkId,
+    'received_at'      => gmdate( 'c' ),
+] );

--- a/server/auth.php
+++ b/server/auth.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Stellt Hilfsfunktionen für die HTTP-Authentifizierung bereit.
+ */
+function wp_monitor_require_basic_auth(array $config, string $responseType = 'json'): void
+{
+    $username     = $config['http_auth']['username'] ?? '';
+    $passwordHash = $config['http_auth']['password_hash'] ?? '';
+
+    if ($username === '' || $passwordHash === '') {
+        return;
+    }
+
+    $realm = $config['http_auth']['realm'] ?? 'WP Monitor';
+
+    $providedUser = $_SERVER['PHP_AUTH_USER'] ?? '';
+    $providedPass = $_SERVER['PHP_AUTH_PW'] ?? '';
+
+    $isValid = ($providedUser === $username) && ($providedPass !== '' && password_verify($providedPass, $passwordHash));
+
+    if ($isValid) {
+        return;
+    }
+
+    header('WWW-Authenticate: Basic realm="' . addslashes($realm) . '", charset="UTF-8"');
+    http_response_code(401);
+
+    if ($responseType === 'json') {
+        if (! headers_sent()) {
+            header('Content-Type: application/json; charset=utf-8');
+        }
+        echo json_encode(['error' => 'Unauthorized.'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    } else {
+        if (! headers_sent()) {
+            header('Content-Type: text/plain; charset=utf-8');
+        }
+        echo 'Unauthorized.';
+    }
+
+    exit;
+}

--- a/server/config.sample.php
+++ b/server/config.sample.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Beispielkonfiguration für den WP Monitor Server.
+ */
+
+return [
+    'db' => [
+        'host'     => '127.0.0.1',
+        'port'     => 3306,
+        'name'     => 'wp_monitor',
+        'user'     => 'wp_monitor',
+        'password' => 'geheimes-passwort',
+        'charset'  => 'utf8mb4',
+    ],
+    'api_keys' => [
+        'mein-api-schluessel' => 'Standardgruppe',
+    ],
+    'http_auth' => [
+        'realm'         => 'WP Monitor',
+        'username'      => 'monitor',
+        'password_hash' => password_hash('ein-sicheres-passwort', PASSWORD_DEFAULT),
+    ],
+];

--- a/server/init.sql
+++ b/server/init.sql
@@ -1,0 +1,72 @@
+-- Schema für den WP Monitor Server
+
+CREATE TABLE IF NOT EXISTS installations (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    site_token VARCHAR(191) NOT NULL,
+    site_url VARCHAR(255) NOT NULL,
+    site_name VARCHAR(191) NOT NULL,
+    site_group VARCHAR(191) DEFAULT NULL,
+    created_at DATETIME NOT NULL,
+    last_seen DATETIME NOT NULL,
+    UNIQUE KEY uq_installations_token (site_token),
+    KEY idx_installations_group (site_group)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS installation_checks (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    installation_id INT UNSIGNED NOT NULL,
+    checked_at DATETIME NOT NULL,
+    wp_version VARCHAR(32) NOT NULL,
+    php_version VARCHAR(32) NOT NULL,
+    mysql_version VARCHAR(64) DEFAULT '',
+    core_updates SMALLINT UNSIGNED DEFAULT 0,
+    core_security_updates SMALLINT UNSIGNED DEFAULT 0,
+    plugin_updates SMALLINT UNSIGNED DEFAULT 0,
+    theme_updates SMALLINT UNSIGNED DEFAULT 0,
+    translation_updates SMALLINT UNSIGNED DEFAULT 0,
+    pending_comments INT UNSIGNED DEFAULT 0,
+    spam_comments INT UNSIGNED DEFAULT 0,
+    registered_users INT UNSIGNED DEFAULT 0,
+    draft_posts INT UNSIGNED DEFAULT 0,
+    published_posts INT UNSIGNED DEFAULT 0,
+    payload LONGTEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_checks_installation FOREIGN KEY (installation_id) REFERENCES installations(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS installation_plugins (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    check_id BIGINT UNSIGNED NOT NULL,
+    plugin_file VARCHAR(255) NOT NULL,
+    plugin_name VARCHAR(191) NOT NULL,
+    plugin_version VARCHAR(50) NOT NULL,
+    is_active TINYINT(1) DEFAULT 0,
+    has_update TINYINT(1) DEFAULT 0,
+    update_version VARCHAR(50) DEFAULT '',
+    CONSTRAINT fk_plugins_check FOREIGN KEY (check_id) REFERENCES installation_checks(id) ON DELETE CASCADE,
+    KEY idx_plugin_file (plugin_file)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS installation_themes (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    check_id BIGINT UNSIGNED NOT NULL,
+    theme_stylesheet VARCHAR(191) NOT NULL,
+    theme_name VARCHAR(191) NOT NULL,
+    theme_version VARCHAR(50) NOT NULL,
+    is_active TINYINT(1) DEFAULT 0,
+    has_update TINYINT(1) DEFAULT 0,
+    update_version VARCHAR(50) DEFAULT '',
+    CONSTRAINT fk_themes_check FOREIGN KEY (check_id) REFERENCES installation_checks(id) ON DELETE CASCADE,
+    KEY idx_theme_stylesheet (theme_stylesheet)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS installation_security (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    check_id BIGINT UNSIGNED NOT NULL,
+    automatic_updates TINYINT(1) DEFAULT 0,
+    force_ssl_admin TINYINT(1) DEFAULT 0,
+    disallow_file_edit TINYINT(1) DEFAULT 0,
+    disallow_file_mods TINYINT(1) DEFAULT 0,
+    core_last_check BIGINT UNSIGNED DEFAULT 0,
+    CONSTRAINT fk_security_check FOREIGN KEY (check_id) REFERENCES installation_checks(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/server/install.php
+++ b/server/install.php
@@ -1,0 +1,264 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+$configPath = __DIR__ . '/config.php';
+$tokenKey   = 'wp_monitor_install_token';
+$configExists = file_exists($configPath);
+
+$currentConfig = [];
+if ($configExists) {
+    $maybeConfig = require $configPath;
+    if (is_array($maybeConfig)) {
+        $currentConfig = $maybeConfig;
+    }
+}
+
+$existingApiKeys   = isset($currentConfig['api_keys']) && is_array($currentConfig['api_keys']) ? $currentConfig['api_keys'] : [];
+$existingApiKey    = array_key_first($existingApiKeys);
+$existingApiGroup  = (null !== $existingApiKey && isset($existingApiKeys[$existingApiKey])) ? (string) $existingApiKeys[$existingApiKey] : 'Standardgruppe';
+$existingApiKeyVal = $existingApiKey ?? '';
+
+if (empty($_SESSION[$tokenKey])) {
+    $_SESSION[$tokenKey] = bin2hex(random_bytes(16));
+}
+
+$errors       = [];
+$success      = false;
+$apiKey       = '';
+$message      = '';
+$httpUsername = $currentConfig['http_auth']['username'] ?? '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $submittedToken = $_POST['token'] ?? '';
+    if (! hash_equals($_SESSION[$tokenKey], $submittedToken)) {
+        $errors[] = 'Ungültiges Formular-Token. Bitte versuche es erneut.';
+    } else {
+        $dbHost = trim((string)($_POST['db_host'] ?? '127.0.0.1'));
+        $dbPort = (int)($_POST['db_port'] ?? 3306);
+        $dbName = trim((string)($_POST['db_name'] ?? ''));
+        $dbUser = trim((string)($_POST['db_user'] ?? ''));
+        $dbPass = (string)($_POST['db_pass'] ?? '');
+
+        $apiKey   = trim((string)($_POST['api_key'] ?? ''));
+        $apiGroup = trim((string)($_POST['api_group'] ?? 'Standardgruppe'));
+
+        $httpRealm     = trim((string)($_POST['http_realm'] ?? 'WP Monitor'));
+        $httpUsername  = trim((string)($_POST['http_username'] ?? ''));
+        $httpPassword  = (string)($_POST['http_password'] ?? '');
+        $httpPassword2 = (string)($_POST['http_password_confirm'] ?? '');
+        $existingPasswordHash = $currentConfig['http_auth']['password_hash'] ?? '';
+        $passwordProvided     = ($httpPassword !== '' || $httpPassword2 !== '');
+
+        if ($dbName === '') {
+            $errors[] = 'Der Datenbankname darf nicht leer sein.';
+        }
+
+        if ($dbUser === '') {
+            $errors[] = 'Der Datenbankbenutzer darf nicht leer sein.';
+        }
+
+        if ($httpUsername === '') {
+            $errors[] = 'Der HTTP-Benutzername darf nicht leer sein.';
+        }
+
+        if ($passwordProvided) {
+            if ($httpPassword === '' || $httpPassword2 === '') {
+                $errors[] = 'Bitte gib das HTTP-Passwort zweimal ein.';
+            }
+        } elseif ($existingPasswordHash === '') {
+            $errors[] = 'Ein HTTP-Passwort ist erforderlich.';
+        }
+
+        if ($passwordProvided && $httpPassword !== $httpPassword2) {
+            $errors[] = 'Die angegebenen HTTP-Passwörter stimmen nicht überein.';
+        }
+
+        if ($apiKey === '') {
+            $apiKey = bin2hex(random_bytes(16));
+        }
+
+        if ($apiGroup === '') {
+            $apiGroup = 'Standardgruppe';
+        }
+
+        if (empty($errors)) {
+            try {
+                $dsn = sprintf(
+                    'mysql:host=%s;port=%d;dbname=%s;charset=utf8mb4',
+                    $dbHost,
+                    $dbPort,
+                    $dbName
+                );
+
+                $pdo = new PDO($dsn, $dbUser, $dbPass, [
+                    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                ]);
+            } catch (Throwable $exception) {
+                $errors[] = 'Datenbankverbindung fehlgeschlagen: ' . $exception->getMessage();
+            }
+        }
+
+        if (empty($errors)) {
+            $schema = @file_get_contents(__DIR__ . '/init.sql');
+            if ($schema === false) {
+                $errors[] = 'Schema-Datei init.sql konnte nicht gelesen werden.';
+            } else {
+                try {
+                    $statements = array_filter(array_map('trim', explode(';', $schema)));
+                    foreach ($statements as $statement) {
+                        if ($statement !== '') {
+                            $pdo->exec($statement);
+                        }
+                    }
+                } catch (Throwable $exception) {
+                    $errors[] = 'Tabellen konnten nicht angelegt werden: ' . $exception->getMessage();
+                }
+            }
+        }
+
+        if (empty($errors)) {
+            $config = [
+                'db' => [
+                    'host'     => $dbHost,
+                    'port'     => $dbPort,
+                    'name'     => $dbName,
+                    'user'     => $dbUser,
+                    'password' => $dbPass,
+                    'charset'  => 'utf8mb4',
+                ],
+                'api_keys' => [
+                    $apiKey => $apiGroup,
+                ],
+                'http_auth' => [
+                    'realm'         => $httpRealm !== '' ? $httpRealm : 'WP Monitor',
+                    'username'      => $httpUsername,
+                    'password_hash' => $passwordProvided ? password_hash($httpPassword, PASSWORD_DEFAULT) : $existingPasswordHash,
+                ],
+            ];
+
+            $configCode = "<?php\nreturn " . var_export($config, true) . ";\n";
+
+            try {
+                if (file_put_contents($configPath, $configCode) === false) {
+                    $errors[] = 'config.php konnte nicht geschrieben werden. Prüfe die Schreibrechte.';
+                } else {
+                    $success = true;
+                    $message = 'Die Installation wurde erfolgreich abgeschlossen.';
+                }
+            } catch (Throwable $exception) {
+                $errors[] = 'config.php konnte nicht geschrieben werden: ' . $exception->getMessage();
+            }
+        }
+    }
+}
+
+if ($success) {
+    $_POST = [];
+}
+
+?><!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8" />
+    <title>WP Monitor Server – Installation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.5; }
+        .container { max-width: 720px; margin: 0 auto; }
+        .success { padding: 1rem; background: #d1fae5; border: 1px solid #10b981; border-radius: 6px; }
+        .error { padding: 1rem; background: #fee2e2; border: 1px solid #ef4444; border-radius: 6px; }
+        form { margin-top: 1.5rem; }
+        label { display: block; margin-top: 1rem; font-weight: 600; }
+        input, textarea { width: 100%; padding: 0.6rem; border: 1px solid #d1d5db; border-radius: 4px; font-size: 1rem; }
+        .actions { margin-top: 1.5rem; }
+        button { padding: 0.8rem 1.4rem; background: #2563eb; color: #fff; border: none; border-radius: 4px; font-size: 1rem; cursor: pointer; }
+        button:hover { background: #1d4ed8; }
+        .note { margin-top: 1rem; font-size: 0.95rem; color: #4b5563; }
+        .readonly { background: #f3f4f6; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>WP Monitor Server – Installation</h1>
+
+    <?php if ($success): ?>
+        <div class="success">
+            <p><?php echo htmlspecialchars($message, ENT_QUOTES, 'UTF-8'); ?></p>
+            <p>API-Schlüssel: <code><?php echo htmlspecialchars($apiKey, ENT_QUOTES, 'UTF-8'); ?></code></p>
+            <p>HTTP-Benutzername: <code><?php echo htmlspecialchars($httpUsername, ENT_QUOTES, 'UTF-8'); ?></code></p>
+            <p>Plugin-Download: <a href="plugin-download.php" target="_blank" rel="noopener">plugin-download.php</a></p>
+            <p class="note">Der Download und die API sind über HTTP-Auth geschützt. Bewahre Benutzername und Passwort sicher auf.</p>
+        </div>
+    <?php endif; ?>
+
+    <?php if (! empty($errors)): ?>
+        <div class="error">
+            <p><strong>Es sind Fehler aufgetreten:</strong></p>
+            <ul>
+                <?php foreach ($errors as $error): ?>
+                    <li><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($configExists && ! $success): ?>
+        <p class="note">
+            Eine bestehende <code>config.php</code> wurde gefunden. Du kannst die Werte aktualisieren und erneut speichern.
+        </p>
+    <?php endif; ?>
+
+    <form method="post" novalidate>
+        <input type="hidden" name="token" value="<?php echo htmlspecialchars($_SESSION[$tokenKey], ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <h2>Datenbank</h2>
+        <label for="db_host">Host</label>
+        <input id="db_host" name="db_host" type="text" required value="<?php echo htmlspecialchars($_POST['db_host'] ?? ($currentConfig['db']['host'] ?? '127.0.0.1'), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="db_port">Port</label>
+        <input id="db_port" name="db_port" type="number" min="1" max="65535" value="<?php echo htmlspecialchars((string)($_POST['db_port'] ?? (string)($currentConfig['db']['port'] ?? '3306')), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="db_name">Datenbankname</label>
+        <input id="db_name" name="db_name" type="text" required value="<?php echo htmlspecialchars($_POST['db_name'] ?? ($currentConfig['db']['name'] ?? 'wp_monitor'), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="db_user">Benutzer</label>
+        <input id="db_user" name="db_user" type="text" required value="<?php echo htmlspecialchars($_POST['db_user'] ?? ($currentConfig['db']['user'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="db_pass">Passwort</label>
+        <input id="db_pass" name="db_pass" type="password" value="<?php echo htmlspecialchars($_POST['db_pass'] ?? '', ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <h2>API-Konfiguration</h2>
+        <label for="api_key">API-Schlüssel (leer lassen für automatischen Schlüssel)</label>
+        <input id="api_key" name="api_key" type="text" value="<?php echo htmlspecialchars($_POST['api_key'] ?? $existingApiKeyVal, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="api_group">Gruppe / Mandant</label>
+        <input id="api_group" name="api_group" type="text" value="<?php echo htmlspecialchars($_POST['api_group'] ?? $existingApiGroup, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <h2>HTTP-Authentifizierung</h2>
+        <label for="http_realm">Realm</label>
+        <input id="http_realm" name="http_realm" type="text" value="<?php echo htmlspecialchars($_POST['http_realm'] ?? ($currentConfig['http_auth']['realm'] ?? 'WP Monitor'), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="http_username">Benutzername</label>
+        <input id="http_username" name="http_username" type="text" required value="<?php echo htmlspecialchars($_POST['http_username'] ?? ($currentConfig['http_auth']['username'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="http_password">Passwort</label>
+        <input id="http_password" name="http_password" type="password" required />
+
+        <label for="http_password_confirm">Passwort bestätigen</label>
+        <input id="http_password_confirm" name="http_password_confirm" type="password" required />
+
+        <div class="actions">
+            <button type="submit">Installation ausführen</button>
+        </div>
+
+        <p class="note">
+            Nach erfolgreicher Installation ist die Datei <code>install.php</code> nicht mehr erforderlich und kann entfernt oder
+            zusätzlich durch den Webserver geschützt werden.
+        </p>
+    </form>
+</div>
+</body>
+</html>

--- a/server/plugin-download.php
+++ b/server/plugin-download.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/auth.php';
+
+$configFile = __DIR__ . '/config.php';
+if (! file_exists($configFile)) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'Server configuration missing.';
+    exit;
+}
+
+$config = require $configFile;
+
+wp_monitor_require_basic_auth($config, 'plain');
+
+$pluginDir = realpath(__DIR__ . '/../plugin/wp-monitor-client');
+if ($pluginDir === false || ! is_dir($pluginDir)) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'Plugin-Verzeichnis wurde nicht gefunden. Stelle sicher, dass "plugin/wp-monitor-client" vorhanden ist.';
+    exit;
+}
+
+if (! class_exists(ZipArchive::class)) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'Die PHP ZipArchive-Erweiterung ist nicht verfügbar.';
+    exit;
+}
+
+$tmpFile = tempnam(sys_get_temp_dir(), 'wpmc_');
+
+$zip = new ZipArchive();
+if ($zip->open($tmpFile, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'ZIP-Datei konnte nicht erstellt werden.';
+    @unlink($tmpFile);
+    exit;
+}
+
+$basePathLength = strlen($pluginDir);
+$rootFolder     = basename($pluginDir);
+
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($pluginDir, FilesystemIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::SELF_FIRST
+);
+
+foreach ($iterator as $fileInfo) {
+    /** @var SplFileInfo $fileInfo */
+    $relativePath = substr($fileInfo->getPathname(), $basePathLength + 1);
+    $localName    = $rootFolder . '/' . str_replace('\\', '/', $relativePath);
+
+    if ($fileInfo->isDir()) {
+        $zip->addEmptyDir($localName);
+    } else {
+        $zip->addFile($fileInfo->getPathname(), $localName);
+    }
+}
+
+$zip->close();
+
+header('Content-Type: application/zip');
+header('Content-Disposition: attachment; filename="wp-monitor-client.zip"');
+header('Content-Length: ' . filesize($tmpFile));
+
+$stream = fopen($tmpFile, 'rb');
+if ($stream !== false) {
+    fpassthru($stream);
+    fclose($stream);
+}
+
+@unlink($tmpFile);
+exit;


### PR DESCRIPTION
## Summary
- implement a reusable HTTP basic-auth helper and secure the API plus plugin download endpoint with it
- add a guided install.php to provision database tables/config and expose plugin-download.php for on-demand ZIP builds
- extend the WordPress client settings for HTTP auth credentials and document the new installation workflow

## Testing
- php -l plugin/wp-monitor-client/includes/class-wp-monitor-client.php
- php -l plugin/wp-monitor-client/wp-monitor-client.php
- php -l server/api.php
- php -l server/auth.php
- php -l server/install.php
- php -l server/plugin-download.php
- php -l server/config.sample.php

------
https://chatgpt.com/codex/tasks/task_e_68e5005b853483339b8d3050ba2ab6c4