### PR TITLE
Surface optional Google rankings in the monitoring dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
-# Wordpress
-eine Wordpress Überwachung Server/client
+# Wordpress Monitoring
+
+Dieses Repository enthält zwei Komponenten, um mehrere WordPress-Installationen zentral zu überwachen:
+
+1. **WP Monitor Client** – ein WordPress-Plugin, das regelmäßig Statusinformationen (Core-, Plugin- & Theme-Versionen, Updates, Benutzerzahlen usw.) sammelt und an einen Server sendet.
+2. **WP Monitor Server** – ein schlankes PHP/MySQL-Skript, das die eingehenden Daten entgegennimmt und in einer Datenbank speichert.
+
+## Schnellstart
+
+### Client (WordPress-Plugin)
+
+1. Kopiere `plugin/wp-monitor-client` in das Verzeichnis `wp-content/plugins/` einer WordPress-Installation.
+2. Aktiviere das Plugin im Backend und öffne **Einstellungen → WP Monitor**.
+3. Trage die URL des Servers sowie einen gültigen API-Schlüssel ein. Optional kannst du eine Installationskennung und das Intervall konfigurieren.
+4. Speichere die Einstellungen. Das Plugin sendet anschließend automatisch Statusberichte im gewünschten Intervall. Eine manuelle Übertragung ist jederzeit möglich.
+
+### Server (API)
+
+1. Kopiere den Ordner `server` auf einen Webserver mit PHP 8.1+ und MySQL/MariaDB.
+2. Rufe `install.php` im Browser auf, um Datenbanktabellen anzulegen, `config.php` zu generieren und HTTP-Auth-Zugangsdaten zu setzen.
+3. Der Server stellt anschließend das Plugin-Paket über `plugin-download.php` bereit (z. B. für `wp plugin install <URL>`), bietet ein Dashboard unter `dashboard.php` und liefert Backups via `backup.php` aus.
+4. Stelle sicher, dass `server/api.php`, `server/dashboard.php`, `server/plugin-download.php` und `server/backup.php` über HTTPS erreichbar sind und per HTTP-Auth geschützt werden.
+5. (Optional) Für Slack-Benachrichtigungen kannst du in der Installation die Slack Webhook URL eines bestehenden Incoming-Webhooks hinterlegen (siehe <https://api.slack.com/messaging/webhooks>). Lässt du das Feld leer, werden einfach keine Slack-Nachrichten versendet – alle Statusdaten landen trotzdem ausschließlich auf deinem eigenen Überwachungsserver.
+
+> **Hinweis:** Slack wird nur benötigt, wenn du Meldungen zusätzlich in einem Slack-Channel empfangen möchtest. Für den normalen Datenfluss zwischen WordPress-Installationen und deinem Monitoring-Server ist keine Slack-Registrierung erforderlich.
+
+## Funktionsumfang
+
+* Überwachung von WordPress-Version, Plugins, Themes und verfügbaren Updates.
+* Zentrales Dashboard mit Filter- und Übersichtskennzahlen für alle Installationen.
+* Anzeige der aktuellsten verfügbaren WordPress-Version inklusive Markierung veralteter Installationen.
+* Direkter Zugriff auf das jeweilige `wp-admin` aus dem Dashboard und Option zum Entfernen veralteter Sites.
+* Erfassung von Sicherheitsindikatoren (z. B. automatische Updates, `DISALLOW_FILE_EDIT`).
+* Automatische Benachrichtigungen per E-Mail und Slack bei kritischen Zuständen.
+* Detailansicht je Site mit SEO-Einstellungen, Wortstatistiken sowie Plugin- und Theme-Zusammenfassungen.
+* Statistiken zu Benutzern, Kommentaren und Beiträgen.
+* Optionales SERP-Tracking via [SerpAPI](https://serpapi.com/) mit Anzeige der besten Google-Position pro Installation.
+* JSON-Backups aller gespeicherten Daten auf Knopfdruck.
+* Erweiterbar über WordPress-Hooks und serverseitige Auswertungen.
+
+### Optional: Slack-Benachrichtigungen
+
+* Slack ist ein zusätzlicher Kanal, falls du Warnungen direkt in einem Slack-Channel sehen möchtest.
+* Ohne eingetragene Webhook-URL bleibt Slack deaktiviert – die WordPress-Installationen senden ihre Daten weiterhin nur an deinen Überwachungsserver.
+* Wenn du Slack nutzen willst, benötigst du einen bestehenden Slack-Workspace mit einem [Incoming-Webhook](https://api.slack.com/messaging/webhooks). Die generierte URL trägst du in der Server-Installation ein.
+
+### Optional: Google-Rankings
+
+* Die SERP-Auswertung nutzt den Drittanbieter SerpAPI. Du hinterlegst den API-Schlüssel einmalig im Server-Installer oder direkt in der `config.php`.
+* Für jede überwachte Installation werden die konfigurierten Suchbegriffe (standardmäßig die Domain) geprüft. Das Dashboard zeigt die beste gefundene Position, die Anzahl erfolgreicher Treffer sowie den Zeitpunkt der letzten Aktualisierung.
+* Lässt du den API-Schlüssel leer, bleibt die Funktion vollständig deaktiviert – alle Monitoring-Daten verbleiben weiterhin ausschließlich auf deinem Server.
+
+## Weiterführende Informationen
+
+* [Plugin-Dokumentation](plugin/wp-monitor-client/README.md)
+* [Server-Dokumentation](server/README.md)
+
+Verbesserungen wie Dashboards, zusätzliche Prüfungen (Backups, SSL-Zertifikate etc.) oder Benachrichtigungen können auf Basis dieser Grundstruktur ergänzt werden.

--- a/plugin/wp-monitor-client/README.md
+++ b/plugin/wp-monitor-client/README.md
@@ -1,0 +1,44 @@
+# WP Monitor Client
+
+Dieses WordPress-Plugin sendet regelmäßig Statusinformationen (Core-, Plugin- und Theme-Versionen, verfügbare Updates, Benutzerzahlen u. v. m.) an einen zentralen WP Monitor Server. Auf dem Server stehen ein Dashboard, Benachrichtigungen und Backup-Exporte bereit, sodass alle angebundenen Installationen auf einen Blick verwaltet werden können.
+
+## Installation
+
+1. Kopiere den Ordner `wp-monitor-client` in das Verzeichnis `wp-content/plugins/` deiner WordPress-Installation.
+2. Aktiviere das Plugin im WordPress-Backend unter **Plugins → Installierte Plugins**.
+3. Öffne anschließend **Einstellungen → WP Monitor** und trage den URL deines Servers sowie den API-Schlüssel ein.
+4. Wenn der Server per HTTP-Authentifizierung geschützt ist, hinterlege dort auch Benutzername und Passwort.
+5. Optional kannst du eine eigene Installationskennung (z. B. Kundenname oder Standort) vergeben und das Sendeintervall anpassen.
+6. Alternativ kann das Plugin direkt von `plugin-download.php` des Servers installiert werden (z. B. via WP-CLI `wp plugin install https://monitor.example.com/plugin-download.php --activate`).
+
+## Funktionsumfang
+
+* Überträgt folgende Informationen:
+  * WordPress-Version und Serverumgebung (PHP, MySQL, Memory-Limits).
+  * Anzahl verfügbarer Core-, Plugin- und Theme-Updates (inkl. Sicherheitsupdates).
+  * Liste aller Plugins/Themes inkl. Update-Status und Aktivierung.
+  * Kommentar- und Benutzerzahlen sowie veröffentlichte/Entwurf-Posts.
+  * SEO-Einstellungen (z. B. Suchmaschinen-Sichtbarkeit, Permalink-Struktur), Wortstatistiken, Plugin-/Theme-Zusammenfassungen und Medienzahlen.
+  * Sicherheitsrelevante Einstellungen (z. B. automatische Updates, `DISALLOW_FILE_EDIT`).
+* Sendet Daten automatisch im gewählten Intervall per WP-Cron.
+* Manuelle Übertragung direkt aus der Einstellungsseite möglich.
+* API-Header (`X-WP-Monitor-*`) helfen dem Server bei der Zuordnung.
+
+## Cron & Debugging
+
+Das Plugin nutzt den WordPress-Cron. Damit automatische Übertragungen funktionieren, muss die Seite regelmäßig aufgerufen werden (oder es wird ein Server-Cronjob eingerichtet, der `wp-cron.php` anstößt).
+
+Bei Problemen findest du in der Browser-Konsole des Adminbereichs und im Fehlerlog deiner WordPress-Instanz weitere Hinweise. Außerdem kannst du die manuelle Übertragung nutzen, um sofortige Rückmeldungen vom Server zu erhalten.
+
+## Erweiterbarkeit
+
+Der gesammelte Datensatz kann über den Filter `wp_monitor_client_snapshot` angepasst werden:
+
+```php
+add_filter( 'wp_monitor_client_snapshot', function ( array $snapshot ) {
+    $snapshot['custom']['health_status'] = get_option( 'health-check-status', 'unknown' );
+    return $snapshot;
+} );
+```
+
+So können projektspezifische Kennzahlen ergänzt werden.

--- a/plugin/wp-monitor-client/includes/class-wp-monitor-client.php
+++ b/plugin/wp-monitor-client/includes/class-wp-monitor-client.php
@@ -1,0 +1,725 @@
+<?php
+/**
+ * Hauptklasse für den WP Monitor Client.
+ *
+ * @package WP_Monitor_Client
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WP_Monitor_Client {
+
+    /**
+     * Cache der Einstellungen.
+     *
+     * @var array|null
+     */
+    private $settings_cache = null;
+
+    /**
+     * Konstruktor – registriert Hooks.
+     */
+    public function __construct() {
+        add_action( 'admin_menu', [ $this, 'register_admin_page' ] );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+        add_action( 'admin_notices', [ $this, 'maybe_render_admin_notice' ] );
+        add_action( WP_MONITOR_CLIENT_CRON_HOOK, [ $this, 'send_snapshot' ] );
+        add_action( 'init', [ $this, 'maybe_schedule_cron' ] );
+        add_filter( 'cron_schedules', [ $this, 'register_custom_interval' ] );
+    }
+
+    /**
+     * Wird bei Aktivierung ausgeführt.
+     */
+    public static function activate() {
+        $instance = wp_monitor_client();
+        $instance->settings_cache = null;
+        $instance->maybe_schedule_cron( true );
+    }
+
+    /**
+     * Wird bei Deaktivierung ausgeführt.
+     */
+    public static function deactivate() {
+        wp_clear_scheduled_hook( WP_MONITOR_CLIENT_CRON_HOOK );
+    }
+
+    /**
+     * Registriert den Menüeintrag in den Einstellungen.
+     */
+    public function register_admin_page() {
+        add_options_page(
+            __( 'WP Monitor Client', 'wp-monitor-client' ),
+            __( 'WP Monitor', 'wp-monitor-client' ),
+            'manage_options',
+            'wp-monitor-client',
+            [ $this, 'render_settings_page' ]
+        );
+    }
+
+    /**
+     * Registriert die Einstellungen.
+     */
+    public function register_settings() {
+        register_setting( 'wp_monitor_client', WP_MONITOR_CLIENT_OPTION, [ $this, 'sanitize_settings' ] );
+
+        add_settings_section(
+            'wp_monitor_client_connection',
+            __( 'Verbindungseinstellungen', 'wp-monitor-client' ),
+            '__return_false',
+            'wp-monitor-client'
+        );
+
+        add_settings_field(
+            'endpoint',
+            __( 'Server-Endpunkt', 'wp-monitor-client' ),
+            [ $this, 'render_endpoint_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_connection'
+        );
+
+        add_settings_field(
+            'api_key',
+            __( 'API-Schlüssel', 'wp-monitor-client' ),
+            [ $this, 'render_api_key_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_connection'
+        );
+
+        add_settings_field(
+            'http_username',
+            __( 'HTTP-Benutzername', 'wp-monitor-client' ),
+            [ $this, 'render_http_username_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_connection'
+        );
+
+        add_settings_field(
+            'http_password',
+            __( 'HTTP-Passwort', 'wp-monitor-client' ),
+            [ $this, 'render_http_password_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_connection'
+        );
+
+        add_settings_field(
+            'site_token',
+            __( 'Installationskennung', 'wp-monitor-client' ),
+            [ $this, 'render_site_token_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_connection'
+        );
+
+        add_settings_section(
+            'wp_monitor_client_schedule',
+            __( 'Übertragung', 'wp-monitor-client' ),
+            '__return_false',
+            'wp-monitor-client'
+        );
+
+        add_settings_field(
+            'interval',
+            __( 'Intervall (Stunden)', 'wp-monitor-client' ),
+            [ $this, 'render_interval_field' ],
+            'wp-monitor-client',
+            'wp_monitor_client_schedule'
+        );
+    }
+
+    /**
+     * Validiert die Einstellungen.
+     */
+    public function sanitize_settings( $settings ) {
+        $defaults = [
+            'endpoint'    => '',
+            'api_key'     => '',
+            'http_username' => '',
+            'http_password' => '',
+            'site_token'  => '',
+            'interval'    => 6,
+        ];
+
+        $existing_settings = $this->get_settings();
+        $raw_settings      = isset( $_POST[ WP_MONITOR_CLIENT_OPTION ] ) ? (array) wp_unslash( $_POST[ WP_MONITOR_CLIENT_OPTION ] ) : [];
+
+        $settings = wp_parse_args( $settings, $defaults );
+
+        $settings['endpoint']   = esc_url_raw( trim( $settings['endpoint'] ) );
+        $settings['api_key']    = sanitize_text_field( $settings['api_key'] );
+        $settings['http_username'] = sanitize_text_field( $settings['http_username'] );
+        $settings['site_token'] = sanitize_text_field( $settings['site_token'] );
+        $settings['interval']   = max( 1, absint( $settings['interval'] ) );
+
+        $submitted_password = isset( $settings['http_password'] ) ? (string) $settings['http_password'] : '';
+        if ( ! empty( $raw_settings['http_password_clear'] ) ) {
+            $settings['http_password'] = '';
+        } elseif ( '' === $submitted_password ) {
+            $settings['http_password'] = $existing_settings['http_password'] ?? '';
+        } else {
+            $settings['http_password'] = sanitize_text_field( $submitted_password );
+        }
+
+        unset( $settings['http_password_clear'] );
+
+        $this->settings_cache = $settings;
+        $this->maybe_reschedule_cron();
+
+        return $settings;
+    }
+
+    /**
+     * Rendert das Einstellungsformular.
+     */
+    public function render_settings_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $settings = $this->get_settings();
+
+        if ( isset( $_POST['wp_monitor_client_send_now'] ) && check_admin_referer( 'wp_monitor_client_send_now' ) ) {
+            $result = $this->send_snapshot();
+            $this->store_admin_notice( $result );
+            wp_safe_redirect( add_query_arg( 'settings-updated', 'true', menu_page_url( 'wp-monitor-client', false ) ) );
+            exit;
+        }
+
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'WP Monitor Client', 'wp-monitor-client' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields( 'wp_monitor_client' );
+                do_settings_sections( 'wp-monitor-client' );
+                submit_button();
+                ?>
+            </form>
+
+            <hr />
+
+            <h2><?php esc_html_e( 'Manuelle Übertragung', 'wp-monitor-client' ); ?></h2>
+            <form method="post">
+                <?php wp_nonce_field( 'wp_monitor_client_send_now' ); ?>
+                <p><?php esc_html_e( 'Sendet sofort einen aktuellen Statusbericht an den Überwachungsserver.', 'wp-monitor-client' ); ?></p>
+                <?php submit_button( __( 'Jetzt senden', 'wp-monitor-client' ), 'secondary', 'wp_monitor_client_send_now' ); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Feld: Endpunkt.
+     */
+    public function render_endpoint_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="url" class="regular-text code" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[endpoint]" value="<?php echo esc_attr( $settings['endpoint'] ); ?>" placeholder="https://monitor.example.com/api.php" />
+        <?php
+    }
+
+    /**
+     * Feld: API-Key.
+     */
+    public function render_api_key_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="text" class="regular-text" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[api_key]" value="<?php echo esc_attr( $settings['api_key'] ); ?>" />
+        <p class="description"><?php esc_html_e( 'Der auf dem Server konfigurierte API-Schlüssel.', 'wp-monitor-client' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Feld: HTTP-Benutzername.
+     */
+    public function render_http_username_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="text" class="regular-text" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[http_username]" value="<?php echo esc_attr( $settings['http_username'] ); ?>" autocomplete="username" />
+        <p class="description"><?php esc_html_e( 'Optionaler Benutzername für HTTP-Basic-Auth auf dem Server.', 'wp-monitor-client' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Feld: HTTP-Passwort.
+     */
+    public function render_http_password_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="password" class="regular-text" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[http_password]" value="" autocomplete="new-password" />
+        <?php if ( ! empty( $settings['http_password'] ) ) : ?>
+            <p class="description"><?php esc_html_e( 'Leer lassen, um das gespeicherte Passwort zu behalten, oder ein neues Passwort eingeben.', 'wp-monitor-client' ); ?></p>
+            <label>
+                <input type="checkbox" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[http_password_clear]" value="1" />
+                <?php esc_html_e( 'Gespeichertes Passwort löschen', 'wp-monitor-client' ); ?>
+            </label>
+        <?php else : ?>
+            <p class="description"><?php esc_html_e( 'Passwort für HTTP-Basic-Auth auf dem Server.', 'wp-monitor-client' ); ?></p>
+        <?php endif; ?>
+        <?php
+    }
+
+    /**
+     * Feld: Site Token.
+     */
+    public function render_site_token_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="text" class="regular-text" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[site_token]" value="<?php echo esc_attr( $settings['site_token'] ); ?>" />
+        <p class="description"><?php esc_html_e( 'Individuelle Kennung dieser Installation (optional).', 'wp-monitor-client' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Feld: Intervall.
+     */
+    public function render_interval_field() {
+        $settings = $this->get_settings();
+        ?>
+        <input type="number" min="1" class="small-text" name="<?php echo esc_attr( WP_MONITOR_CLIENT_OPTION ); ?>[interval]" value="<?php echo esc_attr( $settings['interval'] ); ?>" />
+        <p class="description"><?php esc_html_e( 'In welchem Abstand (in Stunden) Statusdaten versendet werden sollen.', 'wp-monitor-client' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Gibt die Einstellungen zurück.
+     */
+    public function get_settings() {
+        if ( null !== $this->settings_cache ) {
+            return $this->settings_cache;
+        }
+
+        $defaults = [
+            'endpoint'   => '',
+            'api_key'    => '',
+            'site_token' => '',
+            'interval'   => 6,
+        ];
+
+        $this->settings_cache = wp_parse_args( get_option( WP_MONITOR_CLIENT_OPTION, [] ), $defaults );
+
+        return $this->settings_cache;
+    }
+
+    /**
+     * Plant den Cronjob, falls nötig.
+     *
+     * @param bool $force_schedule Erzwingt eine Neuplanung.
+     */
+    public function maybe_schedule_cron( $force_schedule = false ) {
+        if ( $force_schedule ) {
+            $timestamp = wp_next_scheduled( WP_MONITOR_CLIENT_CRON_HOOK );
+            if ( $timestamp ) {
+                wp_unschedule_event( $timestamp, WP_MONITOR_CLIENT_CRON_HOOK );
+            }
+        }
+
+        if ( ! wp_next_scheduled( WP_MONITOR_CLIENT_CRON_HOOK ) ) {
+            $this->schedule_event();
+        }
+    }
+
+    /**
+     * Plant den Cronjob neu, falls sich das Intervall geändert hat.
+     */
+    private function maybe_reschedule_cron() {
+        $timestamp = wp_next_scheduled( WP_MONITOR_CLIENT_CRON_HOOK );
+        if ( $timestamp ) {
+            wp_unschedule_event( $timestamp, WP_MONITOR_CLIENT_CRON_HOOK );
+        }
+
+        $this->schedule_event();
+    }
+
+    /**
+     * Plant das Cron-Event.
+     */
+    private function schedule_event() {
+        wp_schedule_event( time() + MINUTE_IN_SECONDS, 'wp_monitor_client_interval', WP_MONITOR_CLIENT_CRON_HOOK );
+    }
+
+    /**
+     * Registriert das individuelle Cron-Intervall.
+     */
+    public function register_custom_interval( $schedules ) {
+        $settings = $this->get_settings();
+        $interval = max( 1, absint( $settings['interval'] ) );
+
+        $schedules['wp_monitor_client_interval'] = [
+            'interval' => HOUR_IN_SECONDS * $interval,
+            'display'  => sprintf( _n( 'Alle %d Stunde', 'Alle %d Stunden', $interval, 'wp-monitor-client' ), $interval ),
+        ];
+
+        return $schedules;
+    }
+
+    /**
+     * Sendet die gesammelten Daten an den Server.
+     */
+    public function send_snapshot() {
+        $settings = $this->get_settings();
+
+        if ( empty( $settings['endpoint'] ) || empty( $settings['api_key'] ) ) {
+            return [
+                'success' => false,
+                'message' => __( 'Es ist kein Endpunkt oder API-Schlüssel konfiguriert.', 'wp-monitor-client' ),
+            ];
+        }
+
+        $payload = apply_filters( 'wp_monitor_client_snapshot', $this->collect_snapshot() );
+
+        $headers = [
+            'Content-Type'      => 'application/json',
+            'X-WP-Monitor-Key'  => $settings['api_key'],
+            'X-WP-Monitor-Site' => $settings['site_token'] ? $settings['site_token'] : home_url(),
+            'X-WP-Monitor-Version' => WP_MONITOR_CLIENT_VERSION,
+        ];
+
+        if ( ! empty( $settings['http_username'] ) && ! empty( $settings['http_password'] ) ) {
+            $headers['Authorization'] = 'Basic ' . base64_encode( $settings['http_username'] . ':' . $settings['http_password'] );
+        }
+
+        $response = wp_remote_post(
+            $settings['endpoint'],
+            [
+                'timeout' => 20,
+                'headers' => $headers,
+                'body'    => wp_json_encode( $payload ),
+            ]
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return [
+                'success' => false,
+                'message' => $response->get_error_message(),
+            ];
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        $body = wp_remote_retrieve_body( $response );
+
+        if ( $code >= 200 && $code < 300 ) {
+            return [
+                'success' => true,
+                'message' => __( 'Status erfolgreich übertragen.', 'wp-monitor-client' ),
+                'details' => $body,
+            ];
+        }
+
+        return [
+            'success' => false,
+            'message' => sprintf( __( 'Fehlerhafte Antwort vom Server (%d).', 'wp-monitor-client' ), $code ),
+            'details' => $body,
+        ];
+    }
+
+    /**
+     * Sammelt Statusinformationen der WordPress-Installation.
+     */
+    public function collect_snapshot() {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+        global $wpdb;
+
+        $settings      = $this->get_settings();
+        $plugins        = get_plugins();
+        $active_plugins = get_option( 'active_plugins', [] );
+        $plugin_updates = get_site_transient( 'update_plugins' );
+        $plugin_updates = ( is_object( $plugin_updates ) && isset( $plugin_updates->response ) ) ? (array) $plugin_updates->response : [];
+
+        $themes        = wp_get_themes();
+        $theme_updates = get_site_transient( 'update_themes' );
+        $theme_updates = ( is_object( $theme_updates ) && isset( $theme_updates->response ) ) ? (array) $theme_updates->response : [];
+        $current_theme = wp_get_theme();
+
+        $core_updates = get_site_transient( 'update_core' );
+        $update_data  = wp_get_update_data();
+        $core_channels_data = ( is_object( $core_updates ) && isset( $core_updates->updates ) ) ? $core_updates->updates : $core_updates;
+        $comment_counts   = wp_count_comments();
+        $user_counts      = count_users();
+        $post_counts      = wp_count_posts();
+        $multisite        = is_multisite();
+        $page_counts      = function_exists( 'wp_count_posts' ) ? wp_count_posts( 'page' ) : null;
+        $must_use_plugins = function_exists( 'get_mu_plugins' ) ? get_mu_plugins() : [];
+        $dropins          = function_exists( 'get_dropins' ) ? get_dropins() : [];
+
+        $plugin_payload = [];
+        foreach ( $plugins as $file => $data ) {
+            $update_version = '';
+            $has_update     = false;
+
+            if ( isset( $plugin_updates[ $file ] ) ) {
+                $has_update = true;
+                $update     = $plugin_updates[ $file ];
+
+                if ( is_object( $update ) && isset( $update->new_version ) ) {
+                    $update_version = $update->new_version;
+                } elseif ( is_array( $update ) && isset( $update['new_version'] ) ) {
+                    $update_version = $update['new_version'];
+                }
+            }
+
+            $plugin_payload[] = [
+                'file'           => $file,
+                'name'           => $data['Name'],
+                'version'        => $data['Version'],
+                'is_active'      => in_array( $file, $active_plugins, true ),
+                'has_update'     => $has_update,
+                'update_version' => $update_version,
+                'author'         => $data['AuthorName'] ?? '',
+                'plugin_uri'     => $data['PluginURI'] ?? '',
+            ];
+        }
+
+        $theme_payload = [];
+        foreach ( $themes as $stylesheet => $theme ) {
+            $update_version = '';
+            $has_update     = false;
+
+            if ( isset( $theme_updates[ $stylesheet ] ) ) {
+                $has_update = true;
+                $update     = $theme_updates[ $stylesheet ];
+
+                if ( is_array( $update ) && isset( $update['new_version'] ) ) {
+                    $update_version = $update['new_version'];
+                } elseif ( is_object( $update ) && isset( $update->new_version ) ) {
+                    $update_version = $update->new_version;
+                }
+            }
+
+            $theme_payload[] = [
+                'stylesheet'     => $stylesheet,
+                'name'           => $theme->get( 'Name' ),
+                'version'        => $theme->get( 'Version' ),
+                'is_active'      => $current_theme->get_stylesheet() === $stylesheet,
+                'has_update'     => $has_update,
+                'update_version' => $update_version,
+                'author'         => $theme->get( 'Author' ),
+            ];
+        }
+
+        $core_security_updates = isset( $update_data['counts']['security'] ) ? (int) $update_data['counts']['security'] : 0;
+        $core_total_updates    = isset( $update_data['counts']['total'] ) ? (int) $update_data['counts']['total'] : 0;
+        $plugin_update_count   = isset( $update_data['counts']['plugins'] ) ? (int) $update_data['counts']['plugins'] : 0;
+        $theme_update_count    = isset( $update_data['counts']['themes'] ) ? (int) $update_data['counts']['themes'] : 0;
+        $translation_updates   = isset( $update_data['counts']['translations'] ) ? (int) $update_data['counts']['translations'] : 0;
+
+        $php_version   = phpversion();
+        $mysql_version = method_exists( $wpdb, 'db_version' ) ? $wpdb->db_version() : '';
+        $core_last_checked = ( is_object( $core_updates ) && isset( $core_updates->last_checked ) ) ? (int) $core_updates->last_checked : 0;
+
+        $automatic_updates = function_exists( 'wp_is_auto_update_enabled_for_type' ) ? (bool) wp_is_auto_update_enabled_for_type( 'core' ) : false;
+
+        $content_insights = $this->calculate_word_counts();
+        $attachment_total = $this->count_attachments();
+        $uploads_dir      = wp_upload_dir();
+        $uploads_writable = null;
+        if ( ! empty( $uploads_dir['basedir'] ) ) {
+            $uploads_writable = function_exists( 'wp_is_writable' ) ? wp_is_writable( $uploads_dir['basedir'] ) : is_writable( $uploads_dir['basedir'] );
+        }
+        $permalink        = get_option( 'permalink_structure', '' );
+        $site_icon_id     = function_exists( 'get_option' ) ? (int) get_option( 'site_icon' ) : 0;
+
+        $snapshot = [
+            'site' => [
+                'url'        => home_url(),
+                'name'       => get_bloginfo( 'name' ),
+                'language'   => get_bloginfo( 'language' ),
+                'timezone'   => wp_timezone_string(),
+                'token'      => $settings['site_token'],
+            ],
+            'environment' => [
+                'php_version'         => $php_version,
+                'mysql_version'       => $mysql_version,
+                'wp_version'          => get_bloginfo( 'version' ),
+                'is_multisite'        => $multisite,
+                'php_memory_limit'    => ini_get( 'memory_limit' ),
+                'php_max_execution'   => ini_get( 'max_execution_time' ),
+                'wp_debug'            => defined( 'WP_DEBUG' ) ? WP_DEBUG : false,
+            ],
+            'updates' => [
+                'core_available'   => $core_total_updates,
+                'core_security'    => $core_security_updates,
+                'plugins'          => $plugin_update_count,
+                'themes'           => $theme_update_count,
+                'translations'     => $translation_updates,
+                'core_channels'    => $this->normalize_core_updates( $core_channels_data ),
+            ],
+            'plugins' => $plugin_payload,
+            'themes'  => $theme_payload,
+            'counts'  => [
+                'pending_comments' => (int) $comment_counts->moderated,
+                'spam_comments'    => (int) $comment_counts->spam,
+                'registered_users' => (int) $user_counts['total_users'],
+                'draft_posts'      => (int) $post_counts->draft,
+                'published_posts'  => (int) $post_counts->publish,
+            ],
+            'security' => [
+                'last_core_update_check' => $core_last_checked,
+                'automatic_updates'      => $automatic_updates,
+                'force_ssl_admin'        => function_exists( 'force_ssl_admin' ) ? (bool) force_ssl_admin() : false,
+                'disallow_file_edit'     => defined( 'DISALLOW_FILE_EDIT' ) ? (bool) DISALLOW_FILE_EDIT : false,
+                'disallow_file_mods'     => defined( 'DISALLOW_FILE_MODS' ) ? (bool) DISALLOW_FILE_MODS : false,
+            ],
+            'insights' => [
+                'seo'      => [
+                    'tagline'                  => get_bloginfo( 'description' ),
+                    'search_engine_visibility' => (bool) get_option( 'blog_public', 1 ),
+                    'permalink_structure'      => $permalink,
+                    'home_url'                 => home_url(),
+                    'site_icon_set'            => $site_icon_id > 0,
+                ],
+                'content'  => [
+                    'total_words'             => $content_insights['total'] ?? 0,
+                    'words_in_posts'          => $content_insights['posts'] ?? 0,
+                    'words_in_pages'          => $content_insights['pages'] ?? 0,
+                    'average_words_per_post'  => $content_insights['average_post'] ?? 0,
+                    'published_posts'         => (int) $post_counts->publish,
+                    'published_pages'         => $page_counts && isset( $page_counts->publish ) ? (int) $page_counts->publish : 0,
+                ],
+                'plugins'  => [
+                    'total'          => count( $plugins ),
+                    'active'         => count( $active_plugins ),
+                    'inactive'       => max( 0, count( $plugins ) - count( $active_plugins ) ),
+                    'must_use'       => is_array( $must_use_plugins ) ? count( $must_use_plugins ) : 0,
+                    'dropins'        => is_array( $dropins ) ? count( $dropins ) : 0,
+                    'updates'        => $plugin_update_count,
+                ],
+                'themes'   => [
+                    'active'          => $current_theme->get( 'Name' ),
+                    'template'        => $current_theme->get_template(),
+                    'stylesheet'      => $current_theme->get_stylesheet(),
+                    'is_child_theme'  => (bool) $current_theme->parent(),
+                    'available'       => count( $themes ),
+                ],
+                'media'    => [
+                    'attachments'      => $attachment_total,
+                    'uploads_writable' => $uploads_writable,
+                ],
+                'environment' => [
+                    'environment_type' => function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production',
+                    'is_ssl'           => is_ssl(),
+                    'cron_disabled'    => defined( 'DISABLE_WP_CRON' ) ? (bool) DISABLE_WP_CRON : false,
+                ],
+            ],
+            'generated_at' => current_time( 'mysql' ),
+        ];
+
+        return $snapshot;
+    }
+
+    /**
+     * Ermittelt Wortanzahlen für Beiträge und Seiten.
+     *
+     * @return array
+     */
+    private function calculate_word_counts() {
+        global $wpdb;
+
+        $counts = [
+            'total'       => 0,
+            'posts'       => 0,
+            'pages'       => 0,
+            'average_post'=> 0,
+        ];
+
+        if ( ! $wpdb instanceof wpdb ) {
+            return $counts;
+        }
+
+        $posts_words = (int) $wpdb->get_var( "SELECT SUM(CHAR_LENGTH(post_content) - CHAR_LENGTH(REPLACE(post_content, ' ', '')) + 1) FROM {$wpdb->posts} WHERE post_status = 'publish' AND post_type = 'post'" );
+        $pages_words = (int) $wpdb->get_var( "SELECT SUM(CHAR_LENGTH(post_content) - CHAR_LENGTH(REPLACE(post_content, ' ', '')) + 1) FROM {$wpdb->posts} WHERE post_status = 'publish' AND post_type = 'page'" );
+
+        $published_posts = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_status = 'publish' AND post_type = 'post'" );
+
+        $counts['posts']       = max( 0, $posts_words );
+        $counts['pages']       = max( 0, $pages_words );
+        $counts['total']       = max( 0, $posts_words + $pages_words );
+        $counts['average_post']= $published_posts > 0 ? (int) round( $counts['posts'] / $published_posts ) : 0;
+
+        return $counts;
+    }
+
+    /**
+     * Zählt vorhandene Medienanhänge.
+     *
+     * @return int
+     */
+    private function count_attachments() {
+        global $wpdb;
+
+        if ( ! $wpdb instanceof wpdb ) {
+            return 0;
+        }
+
+        $count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'attachment' AND post_status != 'trash'" );
+
+        return max( 0, $count );
+    }
+
+    /**
+     * Normalisiert die Core-Update-Informationen für den Export.
+     */
+    private function normalize_core_updates( $core_updates ) {
+        if ( ! is_array( $core_updates ) && ! is_object( $core_updates ) ) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ( (array) $core_updates as $update ) {
+            if ( ! is_object( $update ) || empty( $update->version ) ) {
+                continue;
+            }
+
+            $normalized[] = [
+                'version'     => $update->version,
+                'php_version' => $update->php_version ?? '',
+                'packages'    => [
+                    'full'    => $update->package ?? '',
+                    'partial' => $update->partial_package ?? '',
+                ],
+                'dismissed'   => ! empty( $update->dismissed ),
+                'current'     => ! empty( $update->current ),
+                'locale'      => $update->locale ?? '',
+            ];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Speichert einen Hinweis für den Admin-Bereich.
+     */
+    private function store_admin_notice( $result ) {
+        set_transient( WP_MONITOR_CLIENT_TRANSIENT, $result, MINUTE_IN_SECONDS * 10 );
+    }
+
+    /**
+     * Gibt gespeicherte Hinweise aus.
+     */
+    public function maybe_render_admin_notice() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $notice = get_transient( WP_MONITOR_CLIENT_TRANSIENT );
+
+        if ( ! $notice ) {
+            return;
+        }
+
+        delete_transient( WP_MONITOR_CLIENT_TRANSIENT );
+
+        $class = $notice['success'] ? 'updated' : 'error';
+        ?>
+        <div class="notice <?php echo esc_attr( $class ); ?> is-dismissible">
+            <p><strong><?php echo esc_html( $notice['message'] ); ?></strong></p>
+            <?php if ( ! empty( $notice['details'] ) ) : ?>
+                <p><code><?php echo esc_html( wp_trim_words( wp_strip_all_tags( $notice['details'] ), 40, '…' ) ); ?></code></p>
+            <?php endif; ?>
+        </div>
+        <?php
+    }
+}

--- a/plugin/wp-monitor-client/wp-monitor-client.php
+++ b/plugin/wp-monitor-client/wp-monitor-client.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Plugin Name:       WP Monitor Client
+ * Plugin URI:        https://example.com/
+ * Description:       Sendet Zustandsdaten der Installation an einen zentralen Überwachungsserver.
+ * Version:           1.0.0
+ * Author:            WP Monitoring
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       wp-monitor-client
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+const WP_MONITOR_CLIENT_VERSION      = '1.0.0';
+const WP_MONITOR_CLIENT_OPTION       = 'wp_monitor_client_settings';
+const WP_MONITOR_CLIENT_CRON_HOOK    = 'wp_monitor_client_send_snapshot';
+const WP_MONITOR_CLIENT_TRANSIENT    = 'wp_monitor_client_admin_notice';
+
+require_once __DIR__ . '/includes/class-wp-monitor-client.php';
+
+function wp_monitor_client() {
+    static $instance = null;
+
+    if ( null === $instance ) {
+        $instance = new WP_Monitor_Client();
+    }
+
+    return $instance;
+}
+
+wp_monitor_client();
+
+register_activation_hook( __FILE__, [ 'WP_Monitor_Client', 'activate' ] );
+register_deactivation_hook( __FILE__, [ 'WP_Monitor_Client', 'deactivate' ] );

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,178 @@
+# WP Monitor Server
+
+Dieses Verzeichnis enthält einen leichtgewichtigen Überwachungsserver, der Statusdaten aus dem „WP Monitor Client“-Plugin entgegennimmt, speichert und als Dashboard aufbereitet. Neben der API sind ein Web-Dashboard, Benachrichtigungen per E-Mail/Slack sowie ein JSON-Backup-Export bereits integriert.
+
+## Installation
+
+1. Lade den Ordner `server` auf deinen Webserver hoch.
+2. Rufe `install.php` im Browser auf (z. B. `https://monitor.example.com/install.php`).
+3. Trage die Datenbankzugangsdaten, einen API-Schlüssel (optional), Zugangsdaten für die HTTP-Authentifizierung, die öffentliche Basis-URL des Dashboards sowie Empfänger für Benachrichtigungen ein. Optional kannst du hier auch die Slack Webhook URL eines Incoming-Webhooks hinterlegen, damit Benachrichtigungen in Slack erscheinen. Ebenfalls optional ist der SerpAPI-Schlüssel für die Google-Ranking-Auswertung. Lässt du eines der Felder leer, bleibt die jeweilige Integration vollständig deaktiviert.
+4. Die Installation legt die Tabellen an, erstellt `config.php` und zeigt dir den generierten API-Schlüssel an.
+5. Nach erfolgreicher Einrichtung kannst du das Plugin direkt über `plugin-download.php` herunterladen, das Dashboard unter `dashboard.php` aufrufen und jederzeit ein Backup über `backup.php` exportieren.
+6. Entferne oder schütze `install.php` zusätzlich, sobald die Installation abgeschlossen ist.
+
+## Konfiguration
+
+```php
+return [
+    'db' => [
+        'host'     => '127.0.0.1',
+        'port'     => 3306,
+        'name'     => 'wp_monitor',
+        'user'     => 'wp_monitor',
+        'password' => 'geheimes-passwort',
+        'charset'  => 'utf8mb4',
+    ],
+    'app' => [
+        'public_url' => 'https://monitor.example.com',
+    ],
+    'api_keys' => [
+        'mein-api-schluessel' => 'Kundenname oder Standort',
+    ],
+    'http_auth' => [
+        'realm'         => 'WP Monitor',
+        'username'      => 'monitor',
+        'password_hash' => '$2y$10$....',
+    ],
+    'notifications' => [
+        'email' => [
+            'recipients' => 'admin@example.com,team@example.com',
+            'from'       => 'monitor@example.com',
+            'subject'    => 'WP Monitor Hinweis',
+        ],
+        'slack' => [
+            'webhook_url' => 'https://hooks.slack.com/services/...',
+        ],
+    ],
+    'serp' => [
+        'api_key'       => 'serp-api-key',
+        'keywords'      => ['%domain%'],
+        'results'       => 10,
+        'google_domain' => 'google.com',
+        'gl'            => '',
+        'hl'            => '',
+        'location'      => '',
+        'timeout'       => 10,
+    ],
+];
+```
+
+* Jeder API-Schlüssel ordnet eingehende Daten einer Gruppe zu (z. B. Kundenname oder Standort).
+* Weitere Installationen können denselben Schlüssel teilen, um sie logisch zusammenzufassen.
+* Die Basic-Auth-Zugangsdaten sichern API, Dashboard (`dashboard.php`), Plugin-Download (`plugin-download.php`) und Backup-Export (`backup.php`).
+* Die Slack Webhook URL ist die Incoming-Webhook-Adresse deines Slack-Workspaces (siehe <https://api.slack.com/messaging/webhooks>). Darüber sendet der Server Statusmeldungen direkt in den ausgewählten Channel.
+* **Keine Pflicht:** Ohne Slack Webhook URL verschickt der Server weiterhin alle E-Mails und nimmt Daten vom Plugin entgegen – Slack ist ein reiner Zusatzkanal.
+* Die SerpAPI-Integration prüft optional die Google-Suchergebnisse für jede Site. Hinterlege dazu deinen SerpAPI-Schlüssel und (optional) eigene Suchbegriffe. Der Platzhalter `%domain%` wird automatisch durch die Domain der jeweiligen Installation ersetzt.
+
+## Erwartetes Datenformat
+
+Das Plugin sendet JSON-Daten mit u. a. folgenden Feldern:
+
+```json
+{
+  "site": {
+    "url": "https://example.com",
+    "name": "Beispielseite",
+    "language": "de-DE",
+    "token": "installation-123"
+  },
+  "environment": {
+    "wp_version": "6.4.3",
+    "php_version": "8.2.7",
+    "mysql_version": "10.11.2-MariaDB",
+    "php_memory_limit": "256M"
+  },
+  "updates": {
+    "core_available": 1,
+    "plugins": 2,
+    "themes": 0
+  },
+  "counts": {
+    "pending_comments": 5,
+    "registered_users": 47
+  },
+  "plugins": [
+    {
+      "file": "akismet/akismet.php",
+      "name": "Akismet",
+      "version": "5.3",
+      "is_active": true,
+      "has_update": false
+    }
+  ],
+  "themes": [],
+  "insights": {
+    "seo": {
+      "tagline": "Meine Seite",
+      "search_engine_visibility": true
+    },
+    "content": {
+      "total_words": 12345,
+      "published_posts": 42
+    },
+    "plugins": {
+      "total": 27,
+      "active": 18
+    },
+    "media": {
+      "attachments": 312
+    }
+  },
+  "generated_at": "2024-04-30 13:37:00"
+}
+```
+
+Alle empfangenen Daten werden zusätzlich als JSON-Blob in der Tabelle `installation_checks.payload` gespeichert, damit später neue Auswertungen möglich sind.
+
+## Antwort des Servers
+
+Bei Erfolg gibt `api.php` eine JSON-Antwort aus:
+
+```json
+{
+  "status": "ok",
+  "installation_id": 1,
+  "check_id": 42,
+  "received_at": "2024-04-30T11:37:22+00:00"
+}
+```
+
+Schlägt etwas fehl, erhält der Client eine passende Fehlermeldung und einen HTTP-Statuscode (z. B. `401 Unauthorized` oder `500 Internal Server Error`).
+
+## Dashboard & Benachrichtigungen
+
+* `dashboard.php` listet alle Installationen mit Filteroptionen für Gruppen und Freitextsuche auf.
+* Die Kopfzeile blendet die von WordPress aktuell veröffentlichte Version ein und markiert Installationen, die hinterherhinken.
+* Der Seitenname ist mit dem jeweiligen `wp-admin` verknüpft, sodass du Updates mit einem Klick im Backend anstoßen kannst.
+* Über den Link **Details** erhältst du pro Installation zusätzliche Kennzahlen (SEO-Einstellungen, Wortanzahl, Plugin-/Theme-Zusammenfassung, Medienstatus usw.).
+* Nicht mehr benötigte Installationen lassen sich direkt im Dashboard löschen – sämtliche zugehörigen Prüfungen werden dabei mit entfernt.
+* Kennzahlen zu offenen Updates, kritischen Core-Sicherheitsupdates und überfälligen Checks werden aggregiert angezeigt.
+* Optional zeigt das Dashboard pro Site den besten gefundenen Google-Rang inklusive Anzahl erfolgreicher Keywords und Zeitpunkt der letzten Aktualisierung an.
+* Beim Eingang einer neuen Meldung verschickt der Server (sofern konfiguriert) Benachrichtigungen per E-Mail und/oder Slack, sobald Sicherheitsupdates, offene Updates oder viele Kommentare vorliegen.
+* `backup.php` liefert einen JSON-Export sämtlicher Tabellen – optional direkt als Download.
+
+### Slack-Benachrichtigungen (optional)
+
+* Die Slack-Anbindung ist ein zusätzlicher Komfortkanal. Die Statusdaten werden weiterhin ausschließlich zwischen Plugin und deinem eigenen Server übertragen.
+* Nur wenn du Slack-Meldungen erhalten möchtest, musst du in deinem Workspace einen Incoming-Webhook anlegen. Eine Anleitung findest du in der [Slack-Dokumentation](https://api.slack.com/messaging/webhooks).
+* Kopiere die erzeugte Webhook-URL in das Installer-Feld oder direkt in `config.php`. Ohne diesen Schritt bleibt Slack deaktiviert, alles andere funktioniert unverändert.
+
+### Google-Rankings (optional)
+
+* Für die SERP-Auswertung nutzt der Server [SerpAPI](https://serpapi.com/). Die Abfragen werden ausschließlich durchgeführt, wenn ein gültiger API-Schlüssel hinterlegt ist.
+* Du kannst im Installer mehrere Suchbegriffe (ein Begriff pro Zeile) angeben. Der Platzhalter `%domain%` ersetzt der Server automatisch durch die Domain jeder überwachten Installation.
+* Die Ergebnisse speichert der Server in der Tabelle `installation_rankings` und zeigt im Dashboard die beste Position pro Site an. Bei Fehlern oder fehlenden Treffern bleibt die Installation weiterhin sichtbar, es werden jedoch keine Ranking-Werte angezeigt.
+
+## Sicherheitshinweise
+
+* Verwende ausschließlich HTTPS, damit API-Schlüssel und Daten geschützt sind.
+* Vergib starke, eindeutige API-Schlüssel und ändere sie regelmäßig.
+* Bewahre die Zugangsdaten für die HTTP-Authentifizierung sicher auf und ändere sie bei Bedarf.
+* Beschränke den Zugriff auf `api.php` zusätzlich (z. B. per Firewall), falls der Endpunkt nicht öffentlich erreichbar sein soll.
+* Überwache die Größe der `payload`-Spalte und rotiere alte Datensätze, um die Datenbank schlank zu halten.
+
+## Erweiterungsideen
+
+* Weitere Benachrichtigungskanäle wie Microsoft Teams oder Telegram.
+* Erweiterte Dashboards mit Diagrammen oder Drill-down in einzelne Checks.
+* Zusätzliche Prüfungen wie SSL-Zertifikatslaufzeit, verfügbare Backups oder Server-Ressourcenauslastung.

--- a/server/api.php
+++ b/server/api.php
@@ -1,0 +1,503 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/notifications.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$configFile = __DIR__ . '/config.php';
+if ( ! file_exists( $configFile ) ) {
+    http_response_code( 500 );
+    echo json_encode( [ 'error' => 'Server configuration missing.' ] );
+    exit;
+}
+
+$config = require $configFile;
+
+wp_monitor_require_basic_auth( $config, 'json' );
+
+if ( $_SERVER['REQUEST_METHOD'] !== 'POST' ) {
+    http_response_code( 405 );
+    header( 'Allow: POST' );
+    echo json_encode( [ 'error' => 'Method not allowed.' ] );
+    exit;
+}
+
+$apiKey = $_SERVER['HTTP_X_WP_MONITOR_KEY'] ?? '';
+if ( empty( $apiKey ) || ! isset( $config['api_keys'][ $apiKey ] ) ) {
+    http_response_code( 401 );
+    echo json_encode( [ 'error' => 'Unauthorized.' ] );
+    exit;
+}
+
+$group = $config['api_keys'][ $apiKey ];
+$siteIdentifier = $_SERVER['HTTP_X_WP_MONITOR_SITE'] ?? '';
+$siteIdentifier = trim( $siteIdentifier );
+
+$rawBody = file_get_contents( 'php://input' );
+$data    = json_decode( $rawBody, true );
+
+if ( json_last_error() !== JSON_ERROR_NONE || ! is_array( $data ) ) {
+    http_response_code( 400 );
+    echo json_encode( [ 'error' => 'Invalid JSON payload.' ] );
+    exit;
+}
+
+try {
+    $dsn = sprintf(
+        'mysql:host=%s;port=%d;dbname=%s;charset=%s',
+        $config['db']['host'],
+        $config['db']['port'],
+        $config['db']['name'],
+        $config['db']['charset'] ?? 'utf8mb4'
+    );
+
+    $pdo = new PDO( $dsn, $config['db']['user'], $config['db']['password'], [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ] );
+} catch ( PDOException $exception ) {
+    http_response_code( 500 );
+    echo json_encode( [ 'error' => 'Database connection failed.', 'message' => $exception->getMessage() ] );
+    exit;
+}
+
+$siteData      = $data['site'] ?? [];
+$environment   = $data['environment'] ?? [];
+$updates       = $data['updates'] ?? [];
+$counts        = $data['counts'] ?? [];
+$security      = $data['security'] ?? [];
+$plugins       = $data['plugins'] ?? [];
+$themes        = $data['themes'] ?? [];
+$generatedAt   = $data['generated_at'] ?? gmdate( 'Y-m-d H:i:s' );
+$siteUrl       = isset( $siteData['url'] ) ? trim( (string) $siteData['url'] ) : '';
+$siteName      = isset( $siteData['name'] ) ? trim( (string) $siteData['name'] ) : '';
+$siteToken     = $siteIdentifier ?: ( isset( $siteData['token'] ) ? (string) $siteData['token'] : '' );
+$siteToken     = $siteToken ?: hash( 'sha256', $siteUrl ?: uniqid( 'site_', true ) );
+
+if ( empty( $siteUrl ) ) {
+    http_response_code( 400 );
+    echo json_encode( [ 'error' => 'Site URL missing in payload.' ] );
+    exit;
+}
+
+$pdo->beginTransaction();
+
+try {
+    $installationId = null;
+
+    $selectStmt = $pdo->prepare( 'SELECT id FROM installations WHERE site_token = :token LIMIT 1' );
+    $selectStmt->execute( [ ':token' => $siteToken ] );
+    $existing = $selectStmt->fetch();
+
+    $now = ( new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d H:i:s' );
+
+    if ( $existing ) {
+        $installationId = (int) $existing['id'];
+        $updateStmt     = $pdo->prepare( 'UPDATE installations SET site_url = :url, site_name = :name, site_group = :grp, last_seen = :seen WHERE id = :id' );
+        $updateStmt->execute( [
+            ':url'  => $siteUrl,
+            ':name' => $siteName,
+            ':grp'  => $group,
+            ':seen' => $now,
+            ':id'   => $installationId,
+        ] );
+    } else {
+        $insertStmt = $pdo->prepare( 'INSERT INTO installations (site_token, site_url, site_name, site_group, created_at, last_seen) VALUES (:token, :url, :name, :grp, :created, :seen)' );
+        $insertStmt->execute( [
+            ':token'   => $siteToken,
+            ':url'     => $siteUrl,
+            ':name'    => $siteName,
+            ':grp'     => $group,
+            ':created' => $now,
+            ':seen'    => $now,
+        ] );
+        $installationId = (int) $pdo->lastInsertId();
+    }
+
+    $insertCheck = $pdo->prepare(
+        'INSERT INTO installation_checks (
+            installation_id,
+            checked_at,
+            wp_version,
+            php_version,
+            mysql_version,
+            core_updates,
+            core_security_updates,
+            plugin_updates,
+            theme_updates,
+            translation_updates,
+            pending_comments,
+            spam_comments,
+            registered_users,
+            draft_posts,
+            published_posts,
+            payload
+        ) VALUES (
+            :installation_id,
+            :checked_at,
+            :wp_version,
+            :php_version,
+            :mysql_version,
+            :core_updates,
+            :core_security_updates,
+            :plugin_updates,
+            :theme_updates,
+            :translation_updates,
+            :pending_comments,
+            :spam_comments,
+            :registered_users,
+            :draft_posts,
+            :published_posts,
+            :payload
+        )'
+    );
+
+    $insertCheck->execute( [
+        ':installation_id'       => $installationId,
+        ':checked_at'            => $generatedAt,
+        ':wp_version'            => (string) ( $environment['wp_version'] ?? '' ),
+        ':php_version'           => (string) ( $environment['php_version'] ?? '' ),
+        ':mysql_version'         => (string) ( $environment['mysql_version'] ?? '' ),
+        ':core_updates'          => (int) ( $updates['core_available'] ?? 0 ),
+        ':core_security_updates' => (int) ( $updates['core_security'] ?? 0 ),
+        ':plugin_updates'        => (int) ( $updates['plugins'] ?? 0 ),
+        ':theme_updates'         => (int) ( $updates['themes'] ?? 0 ),
+        ':translation_updates'   => (int) ( $updates['translations'] ?? 0 ),
+        ':pending_comments'      => (int) ( $counts['pending_comments'] ?? 0 ),
+        ':spam_comments'         => (int) ( $counts['spam_comments'] ?? 0 ),
+        ':registered_users'      => (int) ( $counts['registered_users'] ?? 0 ),
+        ':draft_posts'           => (int) ( $counts['draft_posts'] ?? 0 ),
+        ':published_posts'       => (int) ( $counts['published_posts'] ?? 0 ),
+        ':payload'               => json_encode( $data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+    ] );
+
+    $checkId = (int) $pdo->lastInsertId();
+
+    $pluginStmt = $pdo->prepare( 'INSERT INTO installation_plugins (check_id, plugin_file, plugin_name, plugin_version, is_active, has_update, update_version) VALUES (:check_id, :file, :name, :version, :is_active, :has_update, :update_version)' );
+    foreach ( $plugins as $plugin ) {
+        $pluginStmt->execute( [
+            ':check_id'      => $checkId,
+            ':file'          => substr( (string) ( $plugin['file'] ?? '' ), 0, 255 ),
+            ':name'          => substr( (string) ( $plugin['name'] ?? '' ), 0, 190 ),
+            ':version'       => substr( (string) ( $plugin['version'] ?? '' ), 0, 50 ),
+            ':is_active'     => ! empty( $plugin['is_active'] ) ? 1 : 0,
+            ':has_update'    => ! empty( $plugin['has_update'] ) ? 1 : 0,
+            ':update_version'=> substr( (string) ( $plugin['update_version'] ?? '' ), 0, 50 ),
+        ] );
+    }
+
+    $themeStmt = $pdo->prepare( 'INSERT INTO installation_themes (check_id, theme_stylesheet, theme_name, theme_version, is_active, has_update, update_version) VALUES (:check_id, :stylesheet, :name, :version, :is_active, :has_update, :update_version)' );
+    foreach ( $themes as $theme ) {
+        $themeStmt->execute( [
+            ':check_id'      => $checkId,
+            ':stylesheet'    => substr( (string) ( $theme['stylesheet'] ?? '' ), 0, 191 ),
+            ':name'          => substr( (string) ( $theme['name'] ?? '' ), 0, 190 ),
+            ':version'       => substr( (string) ( $theme['version'] ?? '' ), 0, 50 ),
+            ':is_active'     => ! empty( $theme['is_active'] ) ? 1 : 0,
+            ':has_update'    => ! empty( $theme['has_update'] ) ? 1 : 0,
+            ':update_version'=> substr( (string) ( $theme['update_version'] ?? '' ), 0, 50 ),
+        ] );
+    }
+
+    $securityStmt = $pdo->prepare( 'INSERT INTO installation_security (check_id, automatic_updates, force_ssl_admin, disallow_file_edit, disallow_file_mods, core_last_check) VALUES (:check_id, :automatic_updates, :force_ssl_admin, :disallow_file_edit, :disallow_file_mods, :core_last_check)' );
+    $securityStmt->execute( [
+        ':check_id'           => $checkId,
+        ':automatic_updates'  => ! empty( $security['automatic_updates'] ) ? 1 : 0,
+        ':force_ssl_admin'    => ! empty( $security['force_ssl_admin'] ) ? 1 : 0,
+        ':disallow_file_edit' => ! empty( $security['disallow_file_edit'] ) ? 1 : 0,
+        ':disallow_file_mods' => ! empty( $security['disallow_file_mods'] ) ? 1 : 0,
+        ':core_last_check'    => (int) ( $security['last_core_update_check'] ?? 0 ),
+    ] );
+
+    $pdo->commit();
+} catch ( Throwable $throwable ) {
+    $pdo->rollBack();
+    http_response_code( 500 );
+    echo json_encode( [ 'error' => 'Failed to persist payload.', 'message' => $throwable->getMessage() ] );
+    exit;
+}
+
+try {
+    wp_monitor_refresh_google_rankings( $pdo, $installationId, $siteUrl, $config );
+} catch ( Throwable $exception ) {
+    error_log( '[WP Monitor] Google-Ranking konnte nicht aktualisiert werden: ' . $exception->getMessage() );
+}
+
+$dashboardBase = '';
+if ( ! empty( $config['app']['public_url'] ) ) {
+    $dashboardBase = rtrim( (string) $config['app']['public_url'], '/' );
+}
+
+$securityFlags = [
+    'Automatische Updates'        => ! empty( $security['automatic_updates'] ),
+    'Force SSL Admin'             => ! empty( $security['force_ssl_admin'] ),
+    'Dateieditor deaktiviert'     => ! empty( $security['disallow_file_edit'] ),
+    'Dateimodifikationen gesperrt'=> ! empty( $security['disallow_file_mods'] ),
+];
+
+$summary = [
+    'site_token'            => $siteToken,
+    'site_url'              => $siteUrl,
+    'site_name'             => $siteName,
+    'site_group'            => $group,
+    'checked_at'            => $generatedAt,
+    'core_updates'          => (int) ( $updates['core_available'] ?? 0 ),
+    'core_security_updates' => (int) ( $updates['core_security'] ?? 0 ),
+    'plugin_updates'        => (int) ( $updates['plugins'] ?? 0 ),
+    'theme_updates'         => (int) ( $updates['themes'] ?? 0 ),
+    'translation_updates'   => (int) ( $updates['translations'] ?? 0 ),
+    'pending_comments'      => (int) ( $counts['pending_comments'] ?? 0 ),
+    'spam_comments'         => (int) ( $counts['spam_comments'] ?? 0 ),
+    'security_flags'        => $securityFlags,
+];
+
+if ( $dashboardBase !== '' ) {
+    $summary['dashboard_url'] = $dashboardBase . '/dashboard.php?site=' . urlencode( $siteToken );
+}
+
+wp_monitor_dispatch_notifications( $config, $summary );
+
+echo json_encode( [
+    'status'           => 'ok',
+    'installation_id'  => $installationId,
+    'check_id'         => $checkId,
+    'received_at'      => gmdate( 'c' ),
+] );
+
+/**
+ * Aktualisiert die gespeicherten Google-Rankings für eine Installation, sofern SerpAPI konfiguriert ist.
+ */
+function wp_monitor_refresh_google_rankings( PDO $pdo, int $installationId, string $siteUrl, array $config ): void {
+    $serpConfig = isset( $config['serp'] ) && is_array( $config['serp'] ) ? $config['serp'] : [];
+    $apiKey     = trim( (string) ( $serpConfig['api_key'] ?? '' ) );
+
+    if ( $apiKey === '' ) {
+        return;
+    }
+
+    $host = parse_url( $siteUrl, PHP_URL_HOST );
+    if ( ! is_string( $host ) || $host === '' ) {
+        return;
+    }
+
+    $rawKeywords = $serpConfig['keywords'] ?? [];
+    if ( is_string( $rawKeywords ) ) {
+        $rawKeywords = array_filter( array_map( 'trim', preg_split( '/\r?\n|,/', $rawKeywords ) ) );
+    }
+
+    if ( ! is_array( $rawKeywords ) ) {
+        $rawKeywords = [];
+    }
+
+    $keywords = [];
+    foreach ( $rawKeywords as $keyword ) {
+        $keyword = str_replace( '%domain%', $host, trim( (string) $keyword ) );
+        if ( $keyword !== '' ) {
+            $keywords[] = $keyword;
+        }
+    }
+
+    if ( empty( $keywords ) ) {
+        $keywords = [ $host ];
+    }
+
+    $limit   = (int) ( $serpConfig['results'] ?? 10 );
+    $limit   = max( 1, min( 100, $limit ) );
+    $timeout = (int) ( $serpConfig['timeout'] ?? 10 );
+    $timeout = max( 3, min( 60, $timeout ) );
+
+    $options = [
+        'results'       => $limit,
+        'google_domain' => (string) ( $serpConfig['google_domain'] ?? 'google.com' ),
+        'gl'            => (string) ( $serpConfig['gl'] ?? '' ),
+        'hl'            => (string) ( $serpConfig['hl'] ?? '' ),
+        'location'      => (string) ( $serpConfig['location'] ?? '' ),
+        'timeout'       => $timeout,
+    ];
+
+    $results = [];
+    foreach ( $keywords as $keyword ) {
+        try {
+            $results[] = wp_monitor_fetch_serp_ranking( $apiKey, $keyword, $options, $host );
+        } catch ( Throwable $exception ) {
+            $results[] = [
+                'keyword'      => $keyword,
+                'position'     => null,
+                'title'        => '',
+                'link'         => '',
+                'retrieved_at' => gmdate( 'Y-m-d H:i:s' ),
+                'raw_response' => json_encode( [ 'error' => $exception->getMessage() ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+            ];
+            error_log( '[WP Monitor] Ranking für "' . $keyword . '" konnte nicht geladen werden: ' . $exception->getMessage() );
+        }
+    }
+
+    $pdo->beginTransaction();
+
+    try {
+        $delete = $pdo->prepare( 'DELETE FROM installation_rankings WHERE installation_id = :id' );
+        $delete->execute( [ ':id' => $installationId ] );
+
+        if ( ! empty( $results ) ) {
+            $insert = $pdo->prepare( 'INSERT INTO installation_rankings (installation_id, keyword, position, title, link, retrieved_at, raw_response) VALUES (:installation_id, :keyword, :position, :title, :link, :retrieved_at, :raw_response)' );
+
+            foreach ( $results as $result ) {
+                $insert->execute( [
+                    ':installation_id' => $installationId,
+                    ':keyword'         => substr( (string) ( $result['keyword'] ?? '' ), 0, 255 ),
+                    ':position'        => isset( $result['position'] ) && $result['position'] !== null ? max( 0, (int) $result['position'] ) : null,
+                    ':title'           => substr( (string) ( $result['title'] ?? '' ), 0, 255 ),
+                    ':link'            => substr( (string) ( $result['link'] ?? '' ), 0, 255 ),
+                    ':retrieved_at'    => (string) ( $result['retrieved_at'] ?? gmdate( 'Y-m-d H:i:s' ) ),
+                    ':raw_response'    => (string) ( $result['raw_response'] ?? '' ),
+                ] );
+            }
+        }
+
+        $pdo->commit();
+    } catch ( Throwable $exception ) {
+        $pdo->rollBack();
+        throw $exception;
+    }
+}
+
+/**
+ * Ruft eine SERP-Position über die SerpAPI ab.
+ */
+function wp_monitor_fetch_serp_ranking( string $apiKey, string $keyword, array $options, string $expectedHost ): array {
+    $params = [
+        'engine'  => 'google',
+        'q'       => $keyword,
+        'api_key' => $apiKey,
+        'num'     => max( 1, min( 100, (int) ( $options['results'] ?? 10 ) ) ),
+    ];
+
+    if ( ! empty( $options['google_domain'] ) ) {
+        $params['google_domain'] = $options['google_domain'];
+    }
+    if ( ! empty( $options['gl'] ) ) {
+        $params['gl'] = $options['gl'];
+    }
+    if ( ! empty( $options['hl'] ) ) {
+        $params['hl'] = $options['hl'];
+    }
+    if ( ! empty( $options['location'] ) ) {
+        $params['location'] = $options['location'];
+    }
+
+    $url = 'https://serpapi.com/search.json?' . http_build_query( $params );
+
+    $timeout = max( 3, min( 60, (int) ( $options['timeout'] ?? 10 ) ) );
+    $body    = null;
+    $status  = 0;
+
+    if ( function_exists( 'curl_init' ) ) {
+        $handle = curl_init( $url );
+        if ( false === $handle ) {
+            throw new RuntimeException( 'cURL konnte nicht initialisiert werden.' );
+        }
+
+        curl_setopt( $handle, CURLOPT_RETURNTRANSFER, true );
+        curl_setopt( $handle, CURLOPT_TIMEOUT, $timeout );
+        curl_setopt( $handle, CURLOPT_CONNECTTIMEOUT, min( $timeout, 5 ) );
+
+        $body = curl_exec( $handle );
+        if ( false === $body ) {
+            $error = curl_error( $handle );
+            curl_close( $handle );
+            throw new RuntimeException( 'HTTP-Anfrage fehlgeschlagen: ' . $error );
+        }
+
+        $status = (int) curl_getinfo( $handle, CURLINFO_HTTP_CODE );
+        curl_close( $handle );
+    } else {
+        $context = stream_context_create( [
+            'http' => [
+                'timeout'       => $timeout,
+                'ignore_errors' => true,
+            ],
+        ] );
+
+        $body   = @file_get_contents( $url, false, $context );
+        $status = 0;
+
+        if ( isset( $http_response_header ) && is_array( $http_response_header ) ) {
+            foreach ( $http_response_header as $headerLine ) {
+                if ( preg_match( '/^HTTP\/\S+\s+(\d+)/', $headerLine, $matches ) ) {
+                    $status = (int) $matches[1];
+                    break;
+                }
+            }
+        }
+
+        if ( false === $body ) {
+            throw new RuntimeException( 'HTTP-Anfrage konnte nicht ausgeführt werden.' );
+        }
+    }
+
+    if ( $status >= 400 ) {
+        throw new RuntimeException( 'SerpAPI meldet HTTP-Status ' . $status );
+    }
+
+    $decoded = json_decode( (string) $body, true );
+    if ( ! is_array( $decoded ) ) {
+        throw new RuntimeException( 'Ungültige JSON-Antwort von SerpAPI.' );
+    }
+
+    $position = null;
+    $title    = '';
+    $link     = '';
+
+    $organicResults = $decoded['organic_results'] ?? [];
+    if ( is_array( $organicResults ) ) {
+        foreach ( $organicResults as $result ) {
+            if ( ! is_array( $result ) ) {
+                continue;
+            }
+
+            $resultLink = isset( $result['link'] ) ? (string) $result['link'] : '';
+            if ( $resultLink === '' ) {
+                continue;
+            }
+
+            if ( ! wp_monitor_hosts_match( $resultLink, $expectedHost ) ) {
+                continue;
+            }
+
+            $position = isset( $result['position'] ) ? (int) $result['position'] : null;
+            $title    = isset( $result['title'] ) ? (string) $result['title'] : '';
+            $link     = $resultLink;
+            break;
+        }
+    }
+
+    return [
+        'keyword'      => $keyword,
+        'position'     => $position,
+        'title'        => $title,
+        'link'         => $link,
+        'retrieved_at' => gmdate( 'Y-m-d H:i:s' ),
+        'raw_response' => is_string( $body ) ? $body : json_encode( $decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+    ];
+}
+
+function wp_monitor_hosts_match( string $url, string $expectedHost ): bool {
+    $actualHost = parse_url( $url, PHP_URL_HOST );
+
+    if ( ! is_string( $actualHost ) || $actualHost === '' ) {
+        return false;
+    }
+
+    $normalize = static function ( string $host ): string {
+        $host = strtolower( $host );
+        if ( strpos( $host, 'www.' ) === 0 ) {
+            $host = substr( $host, 4 );
+        }
+
+        return $host;
+    };
+
+    return $normalize( $actualHost ) === $normalize( $expectedHost );
+}

--- a/server/auth.php
+++ b/server/auth.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Stellt Hilfsfunktionen für die HTTP-Authentifizierung bereit.
+ */
+function wp_monitor_require_basic_auth(array $config, string $responseType = 'json'): void
+{
+    $username     = $config['http_auth']['username'] ?? '';
+    $passwordHash = $config['http_auth']['password_hash'] ?? '';
+
+    if ($username === '' || $passwordHash === '') {
+        return;
+    }
+
+    $realm = $config['http_auth']['realm'] ?? 'WP Monitor';
+
+    $providedUser = $_SERVER['PHP_AUTH_USER'] ?? '';
+    $providedPass = $_SERVER['PHP_AUTH_PW'] ?? '';
+
+    $isValid = ($providedUser === $username) && ($providedPass !== '' && password_verify($providedPass, $passwordHash));
+
+    if ($isValid) {
+        return;
+    }
+
+    header('WWW-Authenticate: Basic realm="' . addslashes($realm) . '", charset="UTF-8"');
+    http_response_code(401);
+
+    if ($responseType === 'json') {
+        if (! headers_sent()) {
+            header('Content-Type: application/json; charset=utf-8');
+        }
+        echo json_encode(['error' => 'Unauthorized.'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    } else {
+        if (! headers_sent()) {
+            header('Content-Type: text/plain; charset=utf-8');
+        }
+        echo 'Unauthorized.';
+    }
+
+    exit;
+}

--- a/server/backup.php
+++ b/server/backup.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/auth.php';
+
+$configFile = __DIR__ . '/config.php';
+if (! file_exists($configFile)) {
+    http_response_code(500);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['error' => 'Konfiguration nicht gefunden.']);
+    exit;
+}
+
+$config = require $configFile;
+
+wp_monitor_require_basic_auth($config, 'json');
+
+try {
+    $dsn = sprintf(
+        'mysql:host=%s;port=%d;dbname=%s;charset=%s',
+        $config['db']['host'],
+        $config['db']['port'],
+        $config['db']['name'],
+        $config['db']['charset'] ?? 'utf8mb4'
+    );
+    $pdo = new PDO($dsn, $config['db']['user'], $config['db']['password'], [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+} catch (Throwable $throwable) {
+    http_response_code(500);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['error' => 'Datenbankverbindung fehlgeschlagen', 'message' => $throwable->getMessage()]);
+    exit;
+}
+
+$download = isset($_GET['download']);
+$timestamp = gmdate('Y-m-d_H-i-s');
+
+$payload = [
+    'generated_at' => gmdate('c'),
+    'installations' => $pdo->query('SELECT * FROM installations ORDER BY site_group, site_name')->fetchAll() ?: [],
+    'installation_checks' => $pdo->query('SELECT * FROM installation_checks ORDER BY checked_at DESC')->fetchAll() ?: [],
+    'installation_plugins' => $pdo->query('SELECT * FROM installation_plugins')->fetchAll() ?: [],
+    'installation_themes' => $pdo->query('SELECT * FROM installation_themes')->fetchAll() ?: [],
+    'installation_security' => $pdo->query('SELECT * FROM installation_security')->fetchAll() ?: [],
+    'installation_rankings' => $pdo->query('SELECT * FROM installation_rankings')->fetchAll() ?: [],
+];
+
+$jsonFlags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT;
+$json      = json_encode($payload, $jsonFlags);
+
+if ($json === false) {
+    http_response_code(500);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['error' => 'Backup konnte nicht erstellt werden.']);
+    exit;
+}
+
+if ($download) {
+    header('Content-Type: application/json; charset=utf-8');
+    header('Content-Disposition: attachment; filename="wp-monitor-backup-' . $timestamp . '.json"');
+    echo $json;
+    exit;
+}
+
+header('Content-Type: application/json; charset=utf-8');
+
+echo $json;

--- a/server/config.sample.php
+++ b/server/config.sample.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Beispielkonfiguration für den WP Monitor Server.
+ */
+
+return [
+    'db' => [
+        'host'     => '127.0.0.1',
+        'port'     => 3306,
+        'name'     => 'wp_monitor',
+        'user'     => 'wp_monitor',
+        'password' => 'geheimes-passwort',
+        'charset'  => 'utf8mb4',
+    ],
+    'app' => [
+        'public_url' => 'https://monitor.example.com',
+    ],
+    'api_keys' => [
+        'mein-api-schluessel' => 'Standardgruppe',
+    ],
+    'http_auth' => [
+        'realm'         => 'WP Monitor',
+        'username'      => 'monitor',
+        'password_hash' => password_hash('ein-sicheres-passwort', PASSWORD_DEFAULT),
+    ],
+    'notifications' => [
+        'email' => [
+            'recipients' => 'admin@example.com,team@example.com',
+            'from'       => 'monitor@example.com',
+            'subject'    => 'WP Monitor Hinweis',
+        ],
+        'slack' => [
+            'webhook_url' => 'https://hooks.slack.com/services/...',
+        ],
+    ],
+    'serp' => [
+        'api_key'       => 'serp-api-key',
+        'keywords'      => ['%domain%'],
+        'results'       => 10,
+        'google_domain' => 'google.com',
+        'gl'            => '',
+        'hl'            => '',
+        'location'      => '',
+        'timeout'       => 10,
+    ],
+];

--- a/server/dashboard.php
+++ b/server/dashboard.php
@@ -1,0 +1,711 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/auth.php';
+
+$configFile = __DIR__ . '/config.php';
+if (! file_exists($configFile)) {
+    http_response_code(500);
+    echo 'Konfiguration nicht gefunden.';
+    exit;
+}
+
+$config = require $configFile;
+
+wp_monitor_require_basic_auth($config, 'html');
+
+$serpConfigured = trim((string)($config['serp']['api_key'] ?? '')) !== '';
+
+try {
+    $dsn = sprintf(
+        'mysql:host=%s;port=%d;dbname=%s;charset=%s',
+        $config['db']['host'],
+        $config['db']['port'],
+        $config['db']['name'],
+        $config['db']['charset'] ?? 'utf8mb4'
+    );
+    $pdo = new PDO($dsn, $config['db']['user'], $config['db']['password'], [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+} catch (Throwable $throwable) {
+    http_response_code(500);
+    echo 'Datenbankverbindung fehlgeschlagen: ' . htmlspecialchars($throwable->getMessage(), ENT_QUOTES, 'UTF-8');
+    exit;
+}
+
+$groupFilter  = trim((string)($_GET['group'] ?? ''));
+$searchFilter = trim((string)($_GET['q'] ?? ''));
+$statusNotice = '';
+
+if (isset($_GET['deleted']) && $_GET['deleted'] === '1') {
+    $statusNotice = 'Installation erfolgreich gelöscht.';
+}
+
+$groups = $pdo->query('SELECT DISTINCT site_group FROM installations ORDER BY site_group ASC')->fetchAll(PDO::FETCH_COLUMN) ?: [];
+
+$sql = "
+    SELECT i.id, i.site_name, i.site_url, i.site_group, i.site_token, i.last_seen,
+           c.id AS check_id, c.checked_at, c.wp_version, c.php_version, c.mysql_version,
+           c.core_updates, c.core_security_updates, c.plugin_updates, c.theme_updates, c.translation_updates,
+           c.pending_comments, c.spam_comments, c.registered_users, c.draft_posts, c.published_posts,
+           s.automatic_updates, s.force_ssl_admin, s.disallow_file_edit, s.disallow_file_mods,
+           r.rank_keywords, r.rank_missing, r.rank_best, r.rank_updated
+    FROM installations i
+    LEFT JOIN (
+        SELECT ic.*
+        FROM installation_checks ic
+        INNER JOIN (
+            SELECT installation_id, MAX(checked_at) AS checked_at
+            FROM installation_checks
+            GROUP BY installation_id
+        ) latest ON latest.installation_id = ic.installation_id AND latest.checked_at = ic.checked_at
+    ) c ON c.installation_id = i.id
+    LEFT JOIN installation_security s ON s.check_id = c.id
+    LEFT JOIN (
+        SELECT installation_id,
+               COUNT(*) AS rank_keywords,
+               SUM(CASE WHEN position IS NULL OR position = 0 THEN 1 ELSE 0 END) AS rank_missing,
+               MIN(CASE WHEN position IS NULL OR position = 0 THEN 10000 ELSE position END) AS rank_best,
+               MAX(retrieved_at) AS rank_updated
+        FROM installation_rankings
+        GROUP BY installation_id
+    ) r ON r.installation_id = i.id
+";
+
+$conditions = [];
+$params     = [];
+
+if ($groupFilter !== '') {
+    $conditions[]      = 'i.site_group = :group';
+    $params[':group']  = $groupFilter;
+}
+
+if ($searchFilter !== '') {
+    $conditions[] = '(i.site_name LIKE :search OR i.site_url LIKE :search)';
+    $params[':search'] = '%' . $searchFilter . '%';
+}
+
+if (! empty($conditions)) {
+    $sql .= ' WHERE ' . implode(' AND ', $conditions);
+}
+
+$sql .= ' ORDER BY i.site_group ASC, i.site_name ASC';
+
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$rows = $stmt->fetchAll();
+
+function wp_monitor_row_status(array $row): array
+{
+    $labels = [];
+    $level  = 'ok';
+
+    if (empty($row['check_id'])) {
+        $labels[] = ['label' => 'Keine Daten', 'class' => 'status-missing'];
+        $level    = 'missing';
+        return [$labels, $level];
+    }
+
+    try {
+        $now       = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $checkedAt = new DateTimeImmutable($row['checked_at'] ?? 'now', new DateTimeZone('UTC'));
+        $diffHours = ($now->getTimestamp() - $checkedAt->getTimestamp()) / 3600;
+    } catch (Exception $exception) {
+        $diffHours = 0;
+    }
+
+    if ($diffHours > 24) {
+        $labels[] = ['label' => 'Überfällig', 'class' => 'status-stale'];
+        $level    = 'stale';
+    }
+
+    if ((int)($row['core_security_updates'] ?? 0) > 0) {
+        $labels[] = ['label' => 'Core Sicherheitsupdates', 'class' => 'status-critical'];
+        $level    = 'critical';
+    }
+
+    $updateTotal = (int)($row['core_updates'] ?? 0) + (int)($row['plugin_updates'] ?? 0) + (int)($row['theme_updates'] ?? 0);
+    if ($updateTotal > 0 && $level !== 'critical') {
+        $labels[] = ['label' => 'Updates verfügbar', 'class' => 'status-warning'];
+        $level    = $level === 'ok' ? 'warning' : $level;
+    }
+
+    if ((int)($row['pending_comments'] ?? 0) > 0 && $level === 'ok') {
+        $labels[] = ['label' => 'Kommentare offen', 'class' => 'status-info'];
+        $level    = 'info';
+    }
+
+    if (empty($labels)) {
+        $labels[] = ['label' => 'Alles aktuell', 'class' => 'status-ok'];
+    }
+
+    return [$labels, $level];
+}
+
+function wp_monitor_fetch_latest_wp_version(): array
+{
+    static $cache = null;
+
+    if ($cache !== null) {
+        return $cache;
+    }
+
+    $cacheFile = sys_get_temp_dir() . '/wp-monitor-latest-version.json';
+    $cacheTtl  = 3600;
+
+    if (is_readable($cacheFile)) {
+        $content = file_get_contents($cacheFile);
+        if ($content !== false) {
+            $decoded = json_decode($content, true);
+            if (is_array($decoded) && isset($decoded['version'], $decoded['timestamp'])) {
+                if ((time() - (int)$decoded['timestamp']) < $cacheTtl) {
+                    $cache = [
+                        'version'    => (string)$decoded['version'],
+                        'fetched_at' => (int)$decoded['timestamp'],
+                        'failed'     => (bool)($decoded['failed'] ?? false),
+                    ];
+
+                    return $cache;
+                }
+            }
+        }
+    }
+
+    $latestVersion = '';
+    $failed        = false;
+
+    $context = stream_context_create([
+        'http' => [
+            'timeout' => 5,
+            'user_agent' => 'WP-Monitor-Dashboard',
+        ],
+    ]);
+
+    $response = @file_get_contents('https://api.wordpress.org/core/version-check/1.7/', false, $context);
+
+    if ($response !== false) {
+        $decoded = json_decode($response, true);
+        if (is_array($decoded) && isset($decoded['offers'][0]['current'])) {
+            $latestVersion = (string)$decoded['offers'][0]['current'];
+        } else {
+            $failed = true;
+        }
+    } else {
+        $failed = true;
+    }
+
+    $data = [
+        'version'    => $latestVersion,
+        'timestamp'  => time(),
+        'failed'     => $failed,
+    ];
+
+    @file_put_contents($cacheFile, json_encode($data));
+
+    $cache = [
+        'version'    => $latestVersion,
+        'fetched_at' => $data['timestamp'],
+        'failed'     => $failed,
+    ];
+
+    return $cache;
+}
+
+function wp_monitor_human_bool($value): string
+{
+    if ($value === null) {
+        return 'Unbekannt';
+    }
+
+    return $value ? 'Ja' : 'Nein';
+}
+
+$latestVersionInfo = wp_monitor_fetch_latest_wp_version();
+$latestWpVersion   = $latestVersionInfo['version'] ?? '';
+
+$detailToken = trim((string)($_GET['site'] ?? ''));
+$detailRow   = null;
+$detailPayload = [];
+
+if ($detailToken !== '') {
+    $detailStmt = $pdo->prepare(
+        "SELECT i.*, c.*, s.automatic_updates, s.force_ssl_admin, s.disallow_file_edit, s.disallow_file_mods, s.core_last_check
+         FROM installations i
+         LEFT JOIN installation_checks c ON c.installation_id = i.id
+         LEFT JOIN installation_security s ON s.check_id = c.id
+         WHERE i.site_token = :token
+         ORDER BY c.checked_at DESC
+         LIMIT 1"
+    );
+    $detailStmt->execute([':token' => $detailToken]);
+    $detailRow = $detailStmt->fetch();
+
+    if ($detailRow && ! empty($detailRow['payload'])) {
+        $decoded = json_decode((string)$detailRow['payload'], true);
+        if (is_array($decoded)) {
+            $detailPayload = $decoded;
+        }
+    }
+}
+
+$detailSite        = $detailPayload['site'] ?? [];
+$detailEnvironment = $detailPayload['environment'] ?? [];
+$detailUpdates     = $detailPayload['updates'] ?? [];
+$detailCounts      = $detailPayload['counts'] ?? [];
+$detailSecurity    = $detailPayload['security'] ?? [];
+$detailInsights    = $detailPayload['insights'] ?? [];
+$detailRankings    = [];
+$detailRankingUpdated = null;
+$rankingResultLimit = (int)($config['serp']['results'] ?? 10);
+if ($rankingResultLimit < 1) {
+    $rankingResultLimit = 10;
+}
+$detailRankingUpdatedDisplay = '';
+
+if ($detailRow) {
+    $rankingStmt = $pdo->prepare('SELECT keyword, position, title, link, retrieved_at FROM installation_rankings WHERE installation_id = :id ORDER BY keyword ASC');
+    $rankingStmt->execute([':id' => (int) $detailRow['id']]);
+    $detailRankings = $rankingStmt->fetchAll() ?: [];
+
+    foreach ($detailRankings as $rankingRow) {
+        $retrievedAt = $rankingRow['retrieved_at'] ?? '';
+        if ($retrievedAt === '' || $retrievedAt === null) {
+            continue;
+        }
+
+        if ($detailRankingUpdated === null || strcmp($retrievedAt, $detailRankingUpdated) > 0) {
+            $detailRankingUpdated = $retrievedAt;
+        }
+    }
+
+    if ($detailRankingUpdated !== null) {
+        try {
+            $detailRankingUpdatedDisplay = (new DateTimeImmutable($detailRankingUpdated, new DateTimeZone('UTC')))->format('d.m.Y H:i');
+        } catch (Exception $exception) {
+            $detailRankingUpdatedDisplay = $detailRankingUpdated;
+        }
+    }
+}
+
+?><!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8" />
+    <title>WP Monitor – Dashboard</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+        :root {
+            color-scheme: light dark;
+        }
+        body { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; margin: 2rem; background: #f9fafb; color: #111827; }
+        h1 { margin-bottom: 1.5rem; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1rem; background: #fff; border-radius: 8px; overflow: hidden; }
+        th, td { padding: 0.75rem 1rem; text-align: left; border-bottom: 1px solid #e5e7eb; }
+        th { background: #f3f4f6; font-weight: 600; }
+        tr:last-child td { border-bottom: none; }
+        .filters { display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 1rem; }
+        .filters label { display: flex; flex-direction: column; font-size: 0.9rem; color: #374151; }
+        .filters select, .filters input { padding: 0.5rem; border: 1px solid #d1d5db; border-radius: 6px; min-width: 12rem; }
+        button { padding: 0.55rem 1.1rem; border-radius: 6px; border: none; background: #2563eb; color: #fff; font-weight: 600; cursor: pointer; }
+        button:hover { background: #1d4ed8; }
+        .status-badge { display: inline-block; padding: 0.35rem 0.6rem; border-radius: 999px; font-size: 0.75rem; font-weight: 600; margin-right: 0.25rem; }
+        .status-ok { background: #dcfce7; color: #166534; }
+        .status-warning { background: #fef3c7; color: #92400e; }
+        .status-critical { background: #fee2e2; color: #b91c1c; }
+        .status-info { background: #e0f2fe; color: #1d4ed8; }
+        .status-stale { background: #ede9fe; color: #6d28d9; }
+        .status-missing { background: #f3f4f6; color: #4b5563; }
+        .summary { display: flex; gap: 1.5rem; flex-wrap: wrap; margin-top: 1rem; }
+        .summary-card { background: #fff; padding: 1rem 1.25rem; border-radius: 10px; border: 1px solid #e5e7eb; min-width: 180px; }
+        .summary-card strong { display: block; font-size: 1.8rem; margin-bottom: 0.25rem; }
+        .site-url { font-size: 0.85rem; color: #4b5563; }
+        .security-list { list-style: none; margin: 0.5rem 0 0; padding: 0; font-size: 0.85rem; }
+        .security-list li { margin-bottom: 0.2rem; }
+        a { color: inherit; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        .actions-bar { display: flex; gap: 0.75rem; margin-bottom: 1.5rem; flex-wrap: wrap; }
+        .action-link { padding: 0.55rem 1.1rem; border-radius: 6px; background: #111827; color: #f9fafb; font-weight: 600; }
+        .action-link.secondary { background: #4b5563; }
+        .notice { margin-bottom: 1.25rem; padding: 0.75rem 1rem; border-radius: 6px; background: #ecfdf5; color: #166534; border: 1px solid #a7f3d0; }
+        .button-link { background: none; border: none; padding: 0; font-weight: 600; cursor: pointer; }
+        .button-link:hover { text-decoration: underline; }
+        .button-delete { color: #dc2626; }
+        .actions-cell form { margin: 0; display: inline; }
+        .version-outdated { color: #b91c1c; font-weight: 600; }
+        .latest-version-hint { margin-top: 0.5rem; font-size: 0.95rem; color: #1f2937; }
+        .detail-card { background: #fff; border-radius: 10px; border: 1px solid #e5e7eb; padding: 1.5rem; margin-top: 1.5rem; }
+        .detail-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1.25rem; margin-top: 1rem; }
+        .detail-box { background: #f9fafb; border-radius: 8px; border: 1px solid #e5e7eb; padding: 1rem; }
+        .detail-box h3 { margin-top: 0; font-size: 1rem; margin-bottom: 0.75rem; }
+        .detail-list { list-style: none; padding: 0; margin: 0; font-size: 0.9rem; }
+        .detail-list li { margin-bottom: 0.4rem; }
+        .back-link { display: inline-block; margin-bottom: 1rem; }
+        .detail-highlight { font-weight: 600; }
+        .detail-meta { font-size: 0.85rem; color: #4b5563; margin-top: 0.25rem; }
+        .detail-meta-secondary { font-size: 0.8rem; color: #6b7280; margin-top: 0.6rem; }
+        .detail-empty { margin: 0; font-size: 0.9rem; color: #6b7280; }
+        .table-subtext { font-size: 0.75rem; color: #6b7280; margin-top: 0.25rem; }
+        .ranking-cell { min-width: 170px; }
+    </style>
+</head>
+<body>
+    <h1>WP Monitor – Dashboard</h1>
+
+    <div class="actions-bar">
+        <a class="action-link" href="plugin-download.php">Plugin herunterladen</a>
+        <a class="action-link secondary" href="backup.php?download=1">Backup herunterladen</a>
+    </div>
+
+    <?php if ($statusNotice !== ''): ?>
+        <div class="notice">
+            <?php echo htmlspecialchars($statusNotice, ENT_QUOTES, 'UTF-8'); ?>
+        </div>
+    <?php endif; ?>
+
+    <form method="get" class="filters">
+        <label>
+            Gruppe
+            <select name="group">
+                <option value="">Alle Gruppen</option>
+                <?php foreach ($groups as $groupOption): ?>
+                    <option value="<?php echo htmlspecialchars($groupOption, ENT_QUOTES, 'UTF-8'); ?>" <?php echo $groupOption === $groupFilter ? 'selected' : ''; ?>><?php echo htmlspecialchars($groupOption, ENT_QUOTES, 'UTF-8'); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <label>
+            Suche
+            <input type="search" name="q" value="<?php echo htmlspecialchars($searchFilter, ENT_QUOTES, 'UTF-8'); ?>" placeholder="Domain oder Name" />
+        </label>
+        <div style="align-self: flex-end;">
+            <button type="submit">Filtern</button>
+            <a href="dashboard.php" style="margin-left: 0.5rem;">Zurücksetzen</a>
+        </div>
+    </form>
+
+    <?php
+    $totalInstalls = count($rows);
+    $totalUpdates  = 0;
+    $critical      = 0;
+    $stale         = 0;
+
+    foreach ($rows as $row) {
+        $totalUpdates += (int)($row['core_updates'] ?? 0) + (int)($row['plugin_updates'] ?? 0) + (int)($row['theme_updates'] ?? 0) + (int)($row['translation_updates'] ?? 0);
+        if ((int)($row['core_security_updates'] ?? 0) > 0) {
+            $critical++;
+        }
+        if (! empty($row['checked_at'])) {
+            try {
+                $now  = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+                $last = new DateTimeImmutable($row['checked_at'], new DateTimeZone('UTC'));
+                if ((($now->getTimestamp() - $last->getTimestamp()) / 3600) > 24) {
+                    $stale++;
+                }
+            } catch (Exception $exception) {
+                $stale++;
+            }
+        } else {
+            $stale++;
+        }
+    }
+    ?>
+
+    <div class="summary">
+        <div class="summary-card">
+            <strong><?php echo $totalInstalls; ?></strong>
+            Installationen
+        </div>
+        <div class="summary-card">
+            <strong><?php echo $totalUpdates; ?></strong>
+            Offene Updates
+        </div>
+        <div class="summary-card">
+            <strong><?php echo $critical; ?></strong>
+            Kritische Core Updates
+        </div>
+        <div class="summary-card">
+            <strong><?php echo $stale; ?></strong>
+            Überfällige Checks
+        </div>
+        <div class="summary-card">
+            <strong><?php echo $latestWpVersion !== '' ? htmlspecialchars($latestWpVersion, ENT_QUOTES, 'UTF-8') : '–'; ?></strong>
+            Aktuelle WP-Version
+        </div>
+    </div>
+
+    <?php if ($latestWpVersion === '' && ($latestVersionInfo['failed'] ?? false)): ?>
+        <p class="latest-version-hint">Die aktuelle WordPress-Version konnte nicht automatisch abgefragt werden.</p>
+    <?php elseif ($latestWpVersion !== ''): ?>
+        <p class="latest-version-hint">Letzte Abfrage: <?php echo gmdate('d.m.Y H:i', $latestVersionInfo['fetched_at'] ?? time()); ?> UTC.</p>
+    <?php endif; ?>
+
+    <?php if (! $serpConfigured): ?>
+        <p class="latest-version-hint">Google-Rankings werden erst ermittelt, wenn in der Server-Konfiguration ein SerpAPI-Schlüssel hinterlegt ist.</p>
+    <?php endif; ?>
+
+    <?php if ($detailToken !== ''): ?>
+        <div class="detail-card">
+            <a class="back-link" href="dashboard.php">&larr; Zurück zur Übersicht</a>
+            <?php if (! $detailRow): ?>
+                <p>Für die ausgewählte Installation liegen noch keine Detaildaten vor.</p>
+            <?php else: ?>
+                <?php
+                $detailName      = $detailRow['site_name'] ?: $detailRow['site_url'];
+                $detailUrl       = $detailRow['site_url'];
+                $checkedAt       = $detailRow['checked_at'] ?? '';
+                $detailWpVersion = (string)($detailEnvironment['wp_version'] ?? $detailRow['wp_version'] ?? '');
+                $detailPhp       = (string)($detailEnvironment['php_version'] ?? $detailRow['php_version'] ?? '');
+                $detailMysql     = (string)($detailEnvironment['mysql_version'] ?? $detailRow['mysql_version'] ?? '');
+                $isOutdated      = $latestWpVersion !== '' && $detailWpVersion !== '' && version_compare($detailWpVersion, $latestWpVersion, '<');
+                $seoInfo         = $detailInsights['seo'] ?? [];
+                $contentInfo     = $detailInsights['content'] ?? [];
+                $pluginsInfo     = $detailInsights['plugins'] ?? [];
+                $themesInfo      = $detailInsights['themes'] ?? [];
+                $mediaInfo       = $detailInsights['media'] ?? [];
+                $envInfo         = $detailInsights['environment'] ?? [];
+                ?>
+                <h2>Details f&uuml;r <?php echo htmlspecialchars($detailName, ENT_QUOTES, 'UTF-8'); ?></h2>
+                <p class="detail-meta">
+                    URL: <a href="<?php echo htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener"><?php echo htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?></a><br />
+                    Letzter Check: <?php echo htmlspecialchars($checkedAt ?: 'Unbekannt', ENT_QUOTES, 'UTF-8'); ?>
+                </p>
+                <div class="detail-grid">
+                    <div class="detail-box">
+                        <h3>System</h3>
+                        <ul class="detail-list">
+                            <li><span class="detail-highlight">WordPress:</span> <?php echo htmlspecialchars($detailWpVersion ?: '-', ENT_QUOTES, 'UTF-8'); ?><?php if ($isOutdated): ?> <span class="version-outdated">(Update empfohlen)</span><?php endif; ?></li>
+                            <li><span class="detail-highlight">PHP:</span> <?php echo htmlspecialchars($detailPhp ?: '-', ENT_QUOTES, 'UTF-8'); ?></li>
+                            <li><span class="detail-highlight">MySQL:</span> <?php echo htmlspecialchars($detailMysql ?: '-', ENT_QUOTES, 'UTF-8'); ?></li>
+                            <li><span class="detail-highlight">Sprache:</span> <?php echo htmlspecialchars($detailSite['language'] ?? '-', ENT_QUOTES, 'UTF-8'); ?></li>
+                            <li><span class="detail-highlight">Zeitzone:</span> <?php echo htmlspecialchars($detailSite['timezone'] ?? '-', ENT_QUOTES, 'UTF-8'); ?></li>
+                            <li><span class="detail-highlight">Umgebung:</span> <?php echo htmlspecialchars($envInfo['environment_type'] ?? 'production', ENT_QUOTES, 'UTF-8'); ?></li>
+                            <li><span class="detail-highlight">SSL aktiv:</span> <?php echo wp_monitor_human_bool($envInfo['is_ssl'] ?? null); ?></li>
+                            <li><span class="detail-highlight">WP-Cron deaktiviert:</span> <?php echo wp_monitor_human_bool($envInfo['cron_disabled'] ?? null); ?></li>
+                        </ul>
+                    </div>
+                    <div class="detail-box">
+                        <h3>Updates &amp; Benutzer</h3>
+                        <ul class="detail-list">
+                            <li><span class="detail-highlight">Core-Updates:</span> <?php echo (int)($detailUpdates['core_available'] ?? $detailRow['core_updates'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Core-Security:</span> <?php echo (int)($detailUpdates['core_security'] ?? $detailRow['core_security_updates'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Plugin-Updates:</span> <?php echo (int)($detailUpdates['plugins'] ?? $detailRow['plugin_updates'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Theme-Updates:</span> <?php echo (int)($detailUpdates['themes'] ?? $detailRow['theme_updates'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Übersetzungen:</span> <?php echo (int)($detailUpdates['translations'] ?? $detailRow['translation_updates'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Offene Kommentare:</span> <?php echo (int)($detailCounts['pending_comments'] ?? $detailRow['pending_comments'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Spam-Kommentare:</span> <?php echo (int)($detailCounts['spam_comments'] ?? $detailRow['spam_comments'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Registrierte Benutzer:</span> <?php echo (int)($detailCounts['registered_users'] ?? $detailRow['registered_users'] ?? 0); ?></li>
+                        </ul>
+                    </div>
+                    <div class="detail-box">
+                        <h3>SEO &amp; Sichtbarkeit</h3>
+                        <ul class="detail-list">
+                            <li><span class="detail-highlight">Untertitel:</span> <?php echo htmlspecialchars($seoInfo['tagline'] ?? '-', ENT_QUOTES, 'UTF-8'); ?></li>
+                            <li><span class="detail-highlight">Suchmaschinen:</span> <?php echo ($seoInfo !== [] && isset($seoInfo['search_engine_visibility'])) ? ($seoInfo['search_engine_visibility'] ? 'Indexierung erlaubt' : 'Suchmaschinen blockiert') : 'Unbekannt'; ?></li>
+                            <li><span class="detail-highlight">Permalink-Struktur:</span> <?php echo $seoInfo && ($seoInfo['permalink_structure'] ?? '') !== '' ? htmlspecialchars($seoInfo['permalink_structure'], ENT_QUOTES, 'UTF-8') : 'Standard'; ?></li>
+                            <li><span class="detail-highlight">Site Icon gesetzt:</span> <?php echo wp_monitor_human_bool($seoInfo['site_icon_set'] ?? null); ?></li>
+                        </ul>
+                    </div>
+                    <div class="detail-box">
+                        <h3>Inhalte</h3>
+                        <ul class="detail-list">
+                            <li><span class="detail-highlight">Veröffentlichte Beiträge:</span> <?php echo (int)($contentInfo['published_posts'] ?? $detailRow['published_posts'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Veröffentlichte Seiten:</span> <?php echo (int)($contentInfo['published_pages'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Wörter gesamt:</span> <?php echo (int)($contentInfo['total_words'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Wörter in Beiträgen:</span> <?php echo (int)($contentInfo['words_in_posts'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Wörter in Seiten:</span> <?php echo (int)($contentInfo['words_in_pages'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Ø Wörter pro Beitrag:</span> <?php echo (int)($contentInfo['average_words_per_post'] ?? 0); ?></li>
+                        </ul>
+                    </div>
+                    <div class="detail-box">
+                        <h3>Plugins &amp; Themes</h3>
+                        <ul class="detail-list">
+                            <li><span class="detail-highlight">Plugins gesamt:</span> <?php echo (int)($pluginsInfo['total'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Aktiv:</span> <?php echo (int)($pluginsInfo['active'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Inaktiv:</span> <?php echo (int)($pluginsInfo['inactive'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Must-Use:</span> <?php echo (int)($pluginsInfo['must_use'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Drop-ins:</span> <?php echo (int)($pluginsInfo['dropins'] ?? 0); ?></li>
+                            <li><span class="detail-highlight">Aktives Theme:</span> <?php echo htmlspecialchars($themesInfo['active'] ?? '-', ENT_QUOTES, 'UTF-8'); ?></li>
+                            <li><span class="detail-highlight">Kind-Theme:</span> <?php echo wp_monitor_human_bool($themesInfo['is_child_theme'] ?? null); ?></li>
+                            <li><span class="detail-highlight">Themes installiert:</span> <?php echo (int)($themesInfo['available'] ?? 0); ?></li>
+                        </ul>
+                    </div>
+                    <div class="detail-box">
+                        <h3>Google Rankings</h3>
+                        <?php if (! $serpConfigured): ?>
+                            <p class="detail-empty">Nicht aktiviert.</p>
+                        <?php elseif (empty($detailRankings)): ?>
+                            <p class="detail-empty">Noch keine Ranking-Daten vorhanden.</p>
+                        <?php else: ?>
+                            <ul class="detail-list">
+                                <?php foreach ($detailRankings as $rankingRow): ?>
+                                    <?php
+                                    $keyword  = (string)($rankingRow['keyword'] ?? '');
+                                    $position = isset($rankingRow['position']) ? (int)$rankingRow['position'] : null;
+                                    $link     = (string)($rankingRow['link'] ?? '');
+                                    ?>
+                                    <li>
+                                        <span class="detail-highlight"><?php echo htmlspecialchars($keyword, ENT_QUOTES, 'UTF-8'); ?>:</span>
+                                        <?php if ($position !== null && $position > 0): ?>
+                                            #<?php echo $position; ?>
+                                        <?php else: ?>
+                                            Keine Treffer in den Top <?php echo $rankingResultLimit; ?>
+                                        <?php endif; ?>
+                                        <?php if ($link !== ''): ?>
+                                            – <a href="<?php echo htmlspecialchars($link, ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener">Snippet</a>
+                                        <?php endif; ?>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                            <?php if ($detailRankingUpdatedDisplay !== ''): ?>
+                                <p class="detail-meta detail-meta-secondary">Letzte Aktualisierung: <?php echo htmlspecialchars($detailRankingUpdatedDisplay, ENT_QUOTES, 'UTF-8'); ?> UTC</p>
+                            <?php endif; ?>
+                        <?php endif; ?>
+                    </div>
+                    <div class="detail-box">
+                        <h3>Sicherheit &amp; Dateien</h3>
+                        <ul class="detail-list">
+                            <li><span class="detail-highlight">Auto-Updates:</span> <?php echo wp_monitor_human_bool($detailSecurity['automatic_updates'] ?? null); ?></li>
+                            <li><span class="detail-highlight">SSL im Backend:</span> <?php echo wp_monitor_human_bool($detailSecurity['force_ssl_admin'] ?? null); ?></li>
+                            <li><span class="detail-highlight">Dateieditor gesperrt:</span> <?php echo wp_monitor_human_bool($detailSecurity['disallow_file_edit'] ?? null); ?></li>
+                            <li><span class="detail-highlight">Dateimodifikationen gesperrt:</span> <?php echo wp_monitor_human_bool($detailSecurity['disallow_file_mods'] ?? null); ?></li>
+                            <li><span class="detail-highlight">Uploads beschreibbar:</span> <?php echo wp_monitor_human_bool($mediaInfo['uploads_writable'] ?? null); ?></li>
+                            <li><span class="detail-highlight">Medien gesamt:</span> <?php echo (int)($mediaInfo['attachments'] ?? 0); ?></li>
+                        </ul>
+                    </div>
+                </div>
+            <?php endif; ?>
+        </div>
+    <?php endif; ?>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Website</th>
+                <th>Gruppe</th>
+                <th>WP Version</th>
+                <th>PHP Version</th>
+                <th>Core</th>
+                <th>Plugins</th>
+                <th>Themes</th>
+                <th>Übersetzungen</th>
+                <th>Kommentare</th>
+                <th>Google Ranking</th>
+                <th>Letzter Check</th>
+                <th>Status</th>
+                <th>Aktionen</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (empty($rows)): ?>
+                <tr>
+                    <td colspan="13">Keine Installationen gefunden.</td>
+                </tr>
+            <?php else: ?>
+                <?php foreach ($rows as $row): ?>
+                    <?php
+                    [$badges, $state] = wp_monitor_row_status($row);
+                    $rankKeywords   = (int)($row['rank_keywords'] ?? 0);
+                    $rankMissing    = (int)($row['rank_missing'] ?? 0);
+                    $rankFound      = max(0, $rankKeywords - $rankMissing);
+                    $rankBestRaw    = isset($row['rank_best']) ? (int)$row['rank_best'] : 10000;
+                    $rankBest       = $rankBestRaw >= 10000 ? null : $rankBestRaw;
+                    $rankUpdatedRaw = (string)($row['rank_updated'] ?? '');
+                    $rankUpdatedFormatted = '';
+
+                    if ($rankUpdatedRaw !== '') {
+                        try {
+                            $rankDate             = new DateTimeImmutable($rankUpdatedRaw, new DateTimeZone('UTC'));
+                            $rankUpdatedFormatted = $rankDate->format('d.m.Y H:i');
+                        } catch (Exception $exception) {
+                            $rankUpdatedFormatted = $rankUpdatedRaw;
+                        }
+                    }
+                    ?>
+                    <tr class="state-<?php echo htmlspecialchars($state, ENT_QUOTES, 'UTF-8'); ?>">
+                        <td>
+                            <?php
+                            $adminUrl = '';
+                            if (! empty($row['site_url'])) {
+                                $adminUrl = rtrim($row['site_url'], '/') . '/wp-admin/';
+                            }
+                            ?>
+                            <strong>
+                                <?php if ($adminUrl !== ''): ?>
+                                    <a href="<?php echo htmlspecialchars($adminUrl, ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener">
+                                        <?php echo htmlspecialchars($row['site_name'] ?: $row['site_url'], ENT_QUOTES, 'UTF-8'); ?>
+                                    </a>
+                                <?php else: ?>
+                                    <?php echo htmlspecialchars($row['site_name'] ?: $row['site_url'], ENT_QUOTES, 'UTF-8'); ?>
+                                <?php endif; ?>
+                            </strong>
+                            <div class="site-url">
+                                <a href="<?php echo htmlspecialchars($row['site_url'], ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener"><?php echo htmlspecialchars($row['site_url'], ENT_QUOTES, 'UTF-8'); ?></a>
+                            </div>
+                            <ul class="security-list">
+                                <li>Auto-Updates: <?php echo ! empty($row['automatic_updates']) ? 'aktiv' : 'aus'; ?></li>
+                                <li>SSL im Backend: <?php echo ! empty($row['force_ssl_admin']) ? 'aktiv' : 'aus'; ?></li>
+                                <li>Dateieditor: <?php echo ! empty($row['disallow_file_edit']) ? 'gesperrt' : 'erlaubt'; ?></li>
+                                <li>Dateimodifikationen: <?php echo ! empty($row['disallow_file_mods']) ? 'gesperrt' : 'erlaubt'; ?></li>
+                            </ul>
+                        </td>
+                        <td><?php echo htmlspecialchars($row['site_group'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+                        <td>
+                            <?php
+                            $wpVersionValue = $row['wp_version'] ?? '';
+                            $versionHtml    = htmlspecialchars($wpVersionValue !== '' ? $wpVersionValue : '-', ENT_QUOTES, 'UTF-8');
+                            $isRowOutdated  = $latestWpVersion !== '' && $wpVersionValue !== '' && version_compare($wpVersionValue, $latestWpVersion, '<');
+                            ?>
+                            <?php if ($isRowOutdated): ?>
+                                <span class="version-outdated"><?php echo $versionHtml; ?></span>
+                            <?php else: ?>
+                                <?php echo $versionHtml; ?>
+                            <?php endif; ?>
+                        </td>
+                        <td><?php echo htmlspecialchars($row['php_version'] ?? '-', ENT_QUOTES, 'UTF-8'); ?></td>
+                        <td><?php echo (int)($row['core_updates'] ?? 0); ?><?php if ((int)($row['core_security_updates'] ?? 0) > 0): ?> <span class="status-badge status-critical">Sicherheit</span><?php endif; ?></td>
+                        <td><?php echo (int)($row['plugin_updates'] ?? 0); ?></td>
+                        <td><?php echo (int)($row['theme_updates'] ?? 0); ?></td>
+                        <td><?php echo (int)($row['translation_updates'] ?? 0); ?></td>
+                        <td><?php echo (int)($row['pending_comments'] ?? 0); ?> / <?php echo (int)($row['spam_comments'] ?? 0); ?></td>
+                        <td class="ranking-cell">
+                            <?php if (! $serpConfigured): ?>
+                                –
+                                <div class="table-subtext">Nicht aktiviert</div>
+                            <?php elseif ($rankKeywords === 0): ?>
+                                –
+                                <div class="table-subtext">Keine Daten</div>
+                            <?php else: ?>
+                                <?php if ($rankBest !== null): ?>
+                                    #<?php echo $rankBest; ?>
+                                <?php else: ?>
+                                    Keine Treffer
+                                <?php endif; ?>
+                                <div class="table-subtext">
+                                    <?php echo $rankFound; ?>/<?php echo $rankKeywords; ?> Keywords
+                                    <?php if ($rankUpdatedFormatted !== ''): ?>
+                                        – <?php echo htmlspecialchars($rankUpdatedFormatted, ENT_QUOTES, 'UTF-8'); ?> UTC
+                                    <?php endif; ?>
+                                </div>
+                            <?php endif; ?>
+                        </td>
+                        <td><?php echo htmlspecialchars($row['checked_at'] ?? '-', ENT_QUOTES, 'UTF-8'); ?></td>
+                        <td>
+                            <?php foreach ($badges as $badge): ?>
+                                <span class="status-badge <?php echo htmlspecialchars($badge['class'], ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($badge['label'], ENT_QUOTES, 'UTF-8'); ?></span>
+                            <?php endforeach; ?>
+                        </td>
+                        <td class="actions-cell">
+                            <a href="dashboard.php?site=<?php echo urlencode($row['site_token']); ?>">Details</a>
+                            <form method="post" action="delete-installation.php" onsubmit="return confirm('Installation wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.');">
+                                <input type="hidden" name="installation_id" value="<?php echo (int)$row['id']; ?>" />
+                                <input type="hidden" name="redirect" value="<?php echo htmlspecialchars($_SERVER['REQUEST_URI'] ?? 'dashboard.php', ENT_QUOTES, 'UTF-8'); ?>" />
+                                <button type="submit" class="button-link button-delete">Löschen</button>
+                            </form>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/server/delete-installation.php
+++ b/server/delete-installation.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/auth.php';
+
+$configFile = __DIR__ . '/config.php';
+if (! file_exists($configFile)) {
+    http_response_code(500);
+    echo 'Konfiguration nicht gefunden.';
+    exit;
+}
+
+$config = require $configFile;
+
+wp_monitor_require_basic_auth($config, 'html');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    header('Allow: POST');
+    echo 'Nur POST-Anfragen erlaubt.';
+    exit;
+}
+
+$installationId = (int)($_POST['installation_id'] ?? 0);
+$redirect      = (string)($_POST['redirect'] ?? 'dashboard.php');
+
+if ($installationId <= 0) {
+    http_response_code(400);
+    echo 'Ungültige Installation.';
+    exit;
+}
+
+try {
+    $dsn = sprintf(
+        'mysql:host=%s;port=%d;dbname=%s;charset=%s',
+        $config['db']['host'],
+        $config['db']['port'],
+        $config['db']['name'],
+        $config['db']['charset'] ?? 'utf8mb4'
+    );
+    $pdo = new PDO($dsn, $config['db']['user'], $config['db']['password'], [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+} catch (Throwable $throwable) {
+    http_response_code(500);
+    echo 'Datenbankverbindung fehlgeschlagen: ' . htmlspecialchars($throwable->getMessage(), ENT_QUOTES, 'UTF-8');
+    exit;
+}
+
+$deleteStmt = $pdo->prepare('DELETE FROM installations WHERE id = :id');
+$deleteStmt->execute([':id' => $installationId]);
+
+if ($deleteStmt->rowCount() === 0) {
+    http_response_code(404);
+    echo 'Installation wurde nicht gefunden oder bereits entfernt.';
+    exit;
+}
+
+// Nur relative Weiterleitungen erlauben
+if ($redirect === '' || preg_match('#^(?:[a-z][a-z0-9+\-.]*:)?//#i', $redirect)) {
+    $redirect = 'dashboard.php';
+}
+
+if (strpos($redirect, '?') === false) {
+    $redirect .= '?deleted=1';
+} else {
+    $redirect .= '&deleted=1';
+}
+
+header('Location: ' . $redirect);
+exit;

--- a/server/init.sql
+++ b/server/init.sql
@@ -1,0 +1,86 @@
+-- Schema für den WP Monitor Server
+
+CREATE TABLE IF NOT EXISTS installations (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    site_token VARCHAR(191) NOT NULL,
+    site_url VARCHAR(255) NOT NULL,
+    site_name VARCHAR(191) NOT NULL,
+    site_group VARCHAR(191) DEFAULT NULL,
+    created_at DATETIME NOT NULL,
+    last_seen DATETIME NOT NULL,
+    UNIQUE KEY uq_installations_token (site_token),
+    KEY idx_installations_group (site_group)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS installation_checks (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    installation_id INT UNSIGNED NOT NULL,
+    checked_at DATETIME NOT NULL,
+    wp_version VARCHAR(32) NOT NULL,
+    php_version VARCHAR(32) NOT NULL,
+    mysql_version VARCHAR(64) DEFAULT '',
+    core_updates SMALLINT UNSIGNED DEFAULT 0,
+    core_security_updates SMALLINT UNSIGNED DEFAULT 0,
+    plugin_updates SMALLINT UNSIGNED DEFAULT 0,
+    theme_updates SMALLINT UNSIGNED DEFAULT 0,
+    translation_updates SMALLINT UNSIGNED DEFAULT 0,
+    pending_comments INT UNSIGNED DEFAULT 0,
+    spam_comments INT UNSIGNED DEFAULT 0,
+    registered_users INT UNSIGNED DEFAULT 0,
+    draft_posts INT UNSIGNED DEFAULT 0,
+    published_posts INT UNSIGNED DEFAULT 0,
+    payload LONGTEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_checks_installation FOREIGN KEY (installation_id) REFERENCES installations(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS installation_plugins (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    check_id BIGINT UNSIGNED NOT NULL,
+    plugin_file VARCHAR(255) NOT NULL,
+    plugin_name VARCHAR(191) NOT NULL,
+    plugin_version VARCHAR(50) NOT NULL,
+    is_active TINYINT(1) DEFAULT 0,
+    has_update TINYINT(1) DEFAULT 0,
+    update_version VARCHAR(50) DEFAULT '',
+    CONSTRAINT fk_plugins_check FOREIGN KEY (check_id) REFERENCES installation_checks(id) ON DELETE CASCADE,
+    KEY idx_plugin_file (plugin_file)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS installation_themes (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    check_id BIGINT UNSIGNED NOT NULL,
+    theme_stylesheet VARCHAR(191) NOT NULL,
+    theme_name VARCHAR(191) NOT NULL,
+    theme_version VARCHAR(50) NOT NULL,
+    is_active TINYINT(1) DEFAULT 0,
+    has_update TINYINT(1) DEFAULT 0,
+    update_version VARCHAR(50) DEFAULT '',
+    CONSTRAINT fk_themes_check FOREIGN KEY (check_id) REFERENCES installation_checks(id) ON DELETE CASCADE,
+    KEY idx_theme_stylesheet (theme_stylesheet)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS installation_security (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    check_id BIGINT UNSIGNED NOT NULL,
+    automatic_updates TINYINT(1) DEFAULT 0,
+    force_ssl_admin TINYINT(1) DEFAULT 0,
+    disallow_file_edit TINYINT(1) DEFAULT 0,
+    disallow_file_mods TINYINT(1) DEFAULT 0,
+    core_last_check BIGINT UNSIGNED DEFAULT 0,
+    CONSTRAINT fk_security_check FOREIGN KEY (check_id) REFERENCES installation_checks(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS installation_rankings (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    installation_id INT UNSIGNED NOT NULL,
+    keyword VARCHAR(255) NOT NULL,
+    position SMALLINT UNSIGNED NULL,
+    title VARCHAR(255) DEFAULT '',
+    link VARCHAR(255) DEFAULT '',
+    retrieved_at DATETIME NOT NULL,
+    raw_response LONGTEXT NULL,
+    CONSTRAINT fk_rankings_installation FOREIGN KEY (installation_id) REFERENCES installations(id) ON DELETE CASCADE,
+    KEY idx_rankings_installation (installation_id),
+    KEY idx_rankings_keyword (keyword)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/server/install.php
+++ b/server/install.php
@@ -1,0 +1,432 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+$configPath = __DIR__ . '/config.php';
+$tokenKey   = 'wp_monitor_install_token';
+$configExists = file_exists($configPath);
+
+$currentConfig = [];
+if ($configExists) {
+    $maybeConfig = require $configPath;
+    if (is_array($maybeConfig)) {
+        $currentConfig = $maybeConfig;
+    }
+}
+
+$existingApiKeys   = isset($currentConfig['api_keys']) && is_array($currentConfig['api_keys']) ? $currentConfig['api_keys'] : [];
+$existingApiKey    = array_key_first($existingApiKeys);
+$existingApiGroup  = (null !== $existingApiKey && isset($existingApiKeys[$existingApiKey])) ? (string) $existingApiKeys[$existingApiKey] : 'Standardgruppe';
+$existingApiKeyVal = $existingApiKey ?? '';
+
+if (empty($_SESSION[$tokenKey])) {
+    $_SESSION[$tokenKey] = bin2hex(random_bytes(16));
+}
+
+$errors       = [];
+$success      = false;
+$apiKey       = '';
+$message      = '';
+$httpUsername = $currentConfig['http_auth']['username'] ?? '';
+$existingPasswordHash = $currentConfig['http_auth']['password_hash'] ?? '';
+$requirePasswordInput = $existingPasswordHash === '';
+$existingPublicUrl      = $currentConfig['app']['public_url'] ?? '';
+$existingEmailRecipients = $currentConfig['notifications']['email']['recipients'] ?? '';
+$existingEmailFrom       = $currentConfig['notifications']['email']['from'] ?? '';
+$existingEmailSubject    = $currentConfig['notifications']['email']['subject'] ?? 'WP Monitor Hinweis';
+$existingSlackWebhook    = $currentConfig['notifications']['slack']['webhook_url'] ?? '';
+$existingSerpConfig      = isset($currentConfig['serp']) && is_array($currentConfig['serp']) ? $currentConfig['serp'] : [];
+$existingSerpApiKey      = (string)($existingSerpConfig['api_key'] ?? '');
+$existingSerpKeywords    = $existingSerpConfig['keywords'] ?? [];
+if (is_string($existingSerpKeywords)) {
+    $existingSerpKeywords = array_filter(array_map('trim', preg_split('/\r?\n|,/', $existingSerpKeywords)));
+}
+if (! is_array($existingSerpKeywords)) {
+    $existingSerpKeywords = [];
+}
+$existingSerpKeywordsText = implode("\n", $existingSerpKeywords);
+$existingSerpResults       = (int)($existingSerpConfig['results'] ?? 10);
+$existingSerpDomain        = (string)($existingSerpConfig['google_domain'] ?? 'google.com');
+$existingSerpGl            = (string)($existingSerpConfig['gl'] ?? '');
+$existingSerpHl            = (string)($existingSerpConfig['hl'] ?? '');
+$existingSerpLocation      = (string)($existingSerpConfig['location'] ?? '');
+$existingSerpTimeout       = (int)($existingSerpConfig['timeout'] ?? 10);
+$publicUrl       = $existingPublicUrl;
+$emailRecipients = $existingEmailRecipients;
+$emailFrom       = $existingEmailFrom;
+$emailSubject    = $existingEmailSubject;
+$slackWebhook    = $existingSlackWebhook;
+$serpApiKey      = $existingSerpApiKey;
+$serpKeywordsRaw = $existingSerpKeywordsText;
+$serpResults     = $existingSerpResults;
+$serpDomain      = $existingSerpDomain;
+$serpGl          = $existingSerpGl;
+$serpHl          = $existingSerpHl;
+$serpLocation    = $existingSerpLocation;
+$serpTimeout     = $existingSerpTimeout;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $submittedToken = $_POST['token'] ?? '';
+    if (! hash_equals($_SESSION[$tokenKey], $submittedToken)) {
+        $errors[] = 'Ungültiges Formular-Token. Bitte versuche es erneut.';
+    } else {
+        $dbHost = trim((string)($_POST['db_host'] ?? '127.0.0.1'));
+        $dbPort = (int)($_POST['db_port'] ?? 3306);
+        $dbName = trim((string)($_POST['db_name'] ?? ''));
+        $dbUser = trim((string)($_POST['db_user'] ?? ''));
+        $dbPass = (string)($_POST['db_pass'] ?? '');
+
+        $apiKey   = trim((string)($_POST['api_key'] ?? ''));
+        $apiGroup = trim((string)($_POST['api_group'] ?? 'Standardgruppe'));
+
+        $httpRealm     = trim((string)($_POST['http_realm'] ?? 'WP Monitor'));
+        $httpUsername  = trim((string)($_POST['http_username'] ?? ''));
+        $httpPassword  = (string)($_POST['http_password'] ?? '');
+        $httpPassword2 = (string)($_POST['http_password_confirm'] ?? '');
+        $passwordProvided     = ($httpPassword !== '' || $httpPassword2 !== '');
+
+        $publicUrl       = trim((string)($_POST['public_url'] ?? $existingPublicUrl));
+        $emailRecipients = trim((string)($_POST['email_recipients'] ?? $existingEmailRecipients));
+        $emailFrom       = trim((string)($_POST['email_from'] ?? $existingEmailFrom));
+        $emailSubject    = trim((string)($_POST['email_subject'] ?? $existingEmailSubject));
+        $slackWebhook    = trim((string)($_POST['slack_webhook'] ?? $existingSlackWebhook));
+        $serpApiKey      = trim((string)($_POST['serp_api_key'] ?? $existingSerpApiKey));
+        $serpKeywordsRaw = (string)($_POST['serp_keywords'] ?? $existingSerpKeywordsText);
+        $serpResults     = (int)($_POST['serp_results'] ?? $existingSerpResults);
+        $serpDomain      = trim((string)($_POST['serp_domain'] ?? $existingSerpDomain));
+        $serpGl          = trim((string)($_POST['serp_gl'] ?? $existingSerpGl));
+        $serpHl          = trim((string)($_POST['serp_hl'] ?? $existingSerpHl));
+        $serpLocation    = trim((string)($_POST['serp_location'] ?? $existingSerpLocation));
+        $serpTimeout     = (int)($_POST['serp_timeout'] ?? $existingSerpTimeout);
+
+        if ($emailSubject === '') {
+            $emailSubject = $existingEmailSubject ?: 'WP Monitor Hinweis';
+        }
+
+        if ($serpResults < 1) {
+            $serpResults = 10;
+        }
+        if ($serpResults > 100) {
+            $serpResults = 100;
+        }
+
+        if ($serpTimeout < 3) {
+            $serpTimeout = 3;
+        } elseif ($serpTimeout > 60) {
+            $serpTimeout = 60;
+        }
+
+        $serpKeywords = array_values(array_filter(array_map('trim', preg_split('/\r?\n|,/', $serpKeywordsRaw))));
+        $serpKeywordsRaw = implode("\n", $serpKeywords);
+
+        if ($dbName === '') {
+            $errors[] = 'Der Datenbankname darf nicht leer sein.';
+        }
+
+        if ($dbUser === '') {
+            $errors[] = 'Der Datenbankbenutzer darf nicht leer sein.';
+        }
+
+        if ($httpUsername === '') {
+            $errors[] = 'Der HTTP-Benutzername darf nicht leer sein.';
+        }
+
+        if ($passwordProvided) {
+            if ($httpPassword === '' || $httpPassword2 === '') {
+                $errors[] = 'Bitte gib das HTTP-Passwort zweimal ein.';
+            }
+        } elseif ($existingPasswordHash === '') {
+            $errors[] = 'Ein HTTP-Passwort ist erforderlich.';
+        }
+
+        if ($passwordProvided && $httpPassword !== $httpPassword2) {
+            $errors[] = 'Die angegebenen HTTP-Passwörter stimmen nicht überein.';
+        }
+
+        if ($apiKey === '') {
+            $apiKey = bin2hex(random_bytes(16));
+        }
+
+        if ($apiGroup === '') {
+            $apiGroup = 'Standardgruppe';
+        }
+
+        if (empty($errors)) {
+            try {
+                $dsn = sprintf(
+                    'mysql:host=%s;port=%d;dbname=%s;charset=utf8mb4',
+                    $dbHost,
+                    $dbPort,
+                    $dbName
+                );
+
+                $pdo = new PDO($dsn, $dbUser, $dbPass, [
+                    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                ]);
+            } catch (Throwable $exception) {
+                $errors[] = 'Datenbankverbindung fehlgeschlagen: ' . $exception->getMessage();
+            }
+        }
+
+        if (empty($errors)) {
+            $schema = @file_get_contents(__DIR__ . '/init.sql');
+            if ($schema === false) {
+                $errors[] = 'Schema-Datei init.sql konnte nicht gelesen werden.';
+            } else {
+                try {
+                    $statements = array_filter(array_map('trim', explode(';', $schema)));
+                    foreach ($statements as $statement) {
+                        if ($statement !== '') {
+                            $pdo->exec($statement);
+                        }
+                    }
+                } catch (Throwable $exception) {
+                    $errors[] = 'Tabellen konnten nicht angelegt werden: ' . $exception->getMessage();
+                }
+            }
+        }
+
+        if (empty($errors)) {
+            $config = [
+                'db' => [
+                    'host'     => $dbHost,
+                    'port'     => $dbPort,
+                    'name'     => $dbName,
+                    'user'     => $dbUser,
+                    'password' => $dbPass,
+                    'charset'  => 'utf8mb4',
+                ],
+                'app' => [
+                    'public_url' => $publicUrl,
+                ],
+                'api_keys' => [
+                    $apiKey => $apiGroup,
+                ],
+                'http_auth' => [
+                    'realm'         => $httpRealm !== '' ? $httpRealm : 'WP Monitor',
+                    'username'      => $httpUsername,
+                    'password_hash' => $passwordProvided ? password_hash($httpPassword, PASSWORD_DEFAULT) : $existingPasswordHash,
+                ],
+                'notifications' => [
+                    'email' => [
+                        'recipients' => $emailRecipients,
+                        'from'       => $emailFrom,
+                        'subject'    => $emailSubject,
+                    ],
+                    'slack' => [
+                        'webhook_url' => $slackWebhook,
+                    ],
+                ],
+                'serp' => [
+                    'api_key'       => $serpApiKey,
+                    'keywords'      => $serpKeywords,
+                    'results'       => $serpResults,
+                    'google_domain' => $serpDomain !== '' ? $serpDomain : 'google.com',
+                    'gl'            => $serpGl,
+                    'hl'            => $serpHl,
+                    'location'      => $serpLocation,
+                    'timeout'       => $serpTimeout,
+                ],
+            ];
+
+            $configCode = "<?php\nreturn " . var_export($config, true) . ";\n";
+
+            try {
+                if (file_put_contents($configPath, $configCode) === false) {
+                    $errors[] = 'config.php konnte nicht geschrieben werden. Prüfe die Schreibrechte.';
+                } else {
+                    $success = true;
+                    $message = 'Die Installation wurde erfolgreich abgeschlossen.';
+                }
+            } catch (Throwable $exception) {
+                $errors[] = 'config.php konnte nicht geschrieben werden: ' . $exception->getMessage();
+            }
+        }
+    }
+}
+
+if ($success) {
+    $_POST = [];
+    $requirePasswordInput = false;
+    $serpConfig    = isset($config['serp']) && is_array($config['serp']) ? $config['serp'] : [];
+    $serpApiKey    = (string)($serpConfig['api_key'] ?? '');
+    $serpKeywords  = $serpConfig['keywords'] ?? [];
+    if (is_string($serpKeywords)) {
+        $serpKeywords = array_filter(array_map('trim', preg_split('/\r?\n|,/', $serpKeywords)));
+    }
+    if (! is_array($serpKeywords)) {
+        $serpKeywords = [];
+    }
+    $serpKeywordsRaw = implode("\n", $serpKeywords);
+    $serpResults  = (int)($serpConfig['results'] ?? 10);
+    $serpDomain   = (string)($serpConfig['google_domain'] ?? 'google.com');
+    $serpGl       = (string)($serpConfig['gl'] ?? '');
+    $serpHl       = (string)($serpConfig['hl'] ?? '');
+    $serpLocation = (string)($serpConfig['location'] ?? '');
+    $serpTimeout  = (int)($serpConfig['timeout'] ?? 10);
+}
+
+?><!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8" />
+    <title>WP Monitor Server – Installation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.5; }
+        .container { max-width: 720px; margin: 0 auto; }
+        .success { padding: 1rem; background: #d1fae5; border: 1px solid #10b981; border-radius: 6px; }
+        .error { padding: 1rem; background: #fee2e2; border: 1px solid #ef4444; border-radius: 6px; }
+        form { margin-top: 1.5rem; }
+        label { display: block; margin-top: 1rem; font-weight: 600; }
+        input, textarea { width: 100%; padding: 0.6rem; border: 1px solid #d1d5db; border-radius: 4px; font-size: 1rem; }
+        textarea { min-height: 120px; }
+        .actions { margin-top: 1.5rem; }
+        button { padding: 0.8rem 1.4rem; background: #2563eb; color: #fff; border: none; border-radius: 4px; font-size: 1rem; cursor: pointer; }
+        button:hover { background: #1d4ed8; }
+        .note { margin-top: 1rem; font-size: 0.95rem; color: #4b5563; }
+        .readonly { background: #f3f4f6; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>WP Monitor Server – Installation</h1>
+
+    <?php if ($success): ?>
+        <div class="success">
+            <p><?php echo htmlspecialchars($message, ENT_QUOTES, 'UTF-8'); ?></p>
+            <p>API-Schlüssel: <code><?php echo htmlspecialchars($apiKey, ENT_QUOTES, 'UTF-8'); ?></code></p>
+            <p>HTTP-Benutzername: <code><?php echo htmlspecialchars($httpUsername, ENT_QUOTES, 'UTF-8'); ?></code></p>
+            <p>Dashboard: <a href="dashboard.php" target="_blank" rel="noopener">dashboard.php</a></p>
+            <p>Plugin-Download: <a href="plugin-download.php" target="_blank" rel="noopener">plugin-download.php</a></p>
+            <p>Backup Export: <a href="backup.php?download=1" target="_blank" rel="noopener">backup.php?download=1</a></p>
+            <p class="note">Der Download und die API sind über HTTP-Auth geschützt. Bewahre Benutzername und Passwort sicher auf.</p>
+        </div>
+    <?php endif; ?>
+
+    <?php if (! empty($errors)): ?>
+        <div class="error">
+            <p><strong>Es sind Fehler aufgetreten:</strong></p>
+            <ul>
+                <?php foreach ($errors as $error): ?>
+                    <li><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($configExists && ! $success): ?>
+        <p class="note">
+            Eine bestehende <code>config.php</code> wurde gefunden. Du kannst die Werte aktualisieren und erneut speichern.
+        </p>
+    <?php endif; ?>
+
+    <form method="post" novalidate>
+        <input type="hidden" name="token" value="<?php echo htmlspecialchars($_SESSION[$tokenKey], ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <h2>Datenbank</h2>
+        <label for="db_host">Host</label>
+        <input id="db_host" name="db_host" type="text" required value="<?php echo htmlspecialchars($_POST['db_host'] ?? ($currentConfig['db']['host'] ?? '127.0.0.1'), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="db_port">Port</label>
+        <input id="db_port" name="db_port" type="number" min="1" max="65535" value="<?php echo htmlspecialchars((string)($_POST['db_port'] ?? (string)($currentConfig['db']['port'] ?? '3306')), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="db_name">Datenbankname</label>
+        <input id="db_name" name="db_name" type="text" required value="<?php echo htmlspecialchars($_POST['db_name'] ?? ($currentConfig['db']['name'] ?? 'wp_monitor'), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="db_user">Benutzer</label>
+        <input id="db_user" name="db_user" type="text" required value="<?php echo htmlspecialchars($_POST['db_user'] ?? ($currentConfig['db']['user'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="db_pass">Passwort</label>
+        <input id="db_pass" name="db_pass" type="password" value="<?php echo htmlspecialchars($_POST['db_pass'] ?? '', ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <h2>API-Konfiguration</h2>
+        <label for="api_key">API-Schlüssel (leer lassen für automatischen Schlüssel)</label>
+        <input id="api_key" name="api_key" type="text" value="<?php echo htmlspecialchars($_POST['api_key'] ?? $existingApiKeyVal, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="api_group">Gruppe / Mandant</label>
+        <input id="api_group" name="api_group" type="text" value="<?php echo htmlspecialchars($_POST['api_group'] ?? $existingApiGroup, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <h2>HTTP-Authentifizierung</h2>
+        <label for="http_realm">Realm</label>
+        <input id="http_realm" name="http_realm" type="text" value="<?php echo htmlspecialchars($_POST['http_realm'] ?? ($currentConfig['http_auth']['realm'] ?? 'WP Monitor'), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="http_username">Benutzername</label>
+        <input id="http_username" name="http_username" type="text" required value="<?php echo htmlspecialchars($_POST['http_username'] ?? ($currentConfig['http_auth']['username'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="http_password">Passwort</label>
+        <input id="http_password" name="http_password" type="password" <?php echo $requirePasswordInput ? 'required' : ''; ?> />
+
+        <label for="http_password_confirm">Passwort bestätigen</label>
+        <input id="http_password_confirm" name="http_password_confirm" type="password" <?php echo $requirePasswordInput ? 'required' : ''; ?> />
+
+        <h2>Dashboard &amp; Benachrichtigungen</h2>
+        <label for="public_url">Öffentliche URL des Dashboards</label>
+        <input id="public_url" name="public_url" type="url" placeholder="https://monitor.example.com" value="<?php echo htmlspecialchars($_POST['public_url'] ?? $publicUrl, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="email_recipients">E-Mail Empfänger (Komma getrennt)</label>
+        <input id="email_recipients" name="email_recipients" type="text" value="<?php echo htmlspecialchars($_POST['email_recipients'] ?? $emailRecipients, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="email_from">Absenderadresse</label>
+        <input id="email_from" name="email_from" type="email" value="<?php echo htmlspecialchars($_POST['email_from'] ?? $emailFrom, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="email_subject">E-Mail Betreff</label>
+        <input id="email_subject" name="email_subject" type="text" value="<?php echo htmlspecialchars($_POST['email_subject'] ?? $emailSubject, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="slack_webhook">Slack Webhook URL (optional)</label>
+        <input id="slack_webhook" name="slack_webhook" type="url" value="<?php echo htmlspecialchars($_POST['slack_webhook'] ?? $slackWebhook, ENT_QUOTES, 'UTF-8'); ?>" />
+        <p class="note">
+            Hinterlege hier die von Slack generierte Incoming-Webhook-URL (z. B. <code>https://hooks.slack.com/services/…</code>),
+            damit der Server Statusmeldungen direkt an einen Slack-Channel senden kann. Lässt du das Feld leer, bleibt Slack
+            deaktiviert und alle Daten werden trotzdem nur auf deinem Überwachungsserver gespeichert.
+        </p>
+
+        <h2>Google Rankings (optional)</h2>
+        <label for="serp_api_key">SerpAPI Schlüssel</label>
+        <input id="serp_api_key" name="serp_api_key" type="text" value="<?php echo htmlspecialchars($_POST['serp_api_key'] ?? $serpApiKey, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="serp_keywords">Suchbegriffe (ein Begriff pro Zeile)</label>
+        <textarea id="serp_keywords" name="serp_keywords" placeholder="%domain%&#10;wordpress agentur berlin"><?php echo htmlspecialchars($_POST['serp_keywords'] ?? $serpKeywordsRaw, ENT_QUOTES, 'UTF-8'); ?></textarea>
+        <p class="note">
+            Nutze <code>%domain%</code> als Platzhalter für die Domain der jeweiligen Installation. Lässt du die Liste leer,
+            wird automatisch nur nach der Domain gesucht.
+        </p>
+
+        <label for="serp_results">Anzahl der ausgewerteten Ergebnisse</label>
+        <input id="serp_results" name="serp_results" type="number" min="1" max="100" value="<?php echo htmlspecialchars((string)($_POST['serp_results'] ?? (string)$serpResults), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="serp_domain">Google-Domain (z. B. google.com)</label>
+        <input id="serp_domain" name="serp_domain" type="text" value="<?php echo htmlspecialchars($_POST['serp_domain'] ?? $serpDomain, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="serp_gl">Google Country Code (gl)</label>
+        <input id="serp_gl" name="serp_gl" type="text" value="<?php echo htmlspecialchars($_POST['serp_gl'] ?? $serpGl, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="serp_hl">Google Language (hl)</label>
+        <input id="serp_hl" name="serp_hl" type="text" value="<?php echo htmlspecialchars($_POST['serp_hl'] ?? $serpHl, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="serp_location">Standort (optional)</label>
+        <input id="serp_location" name="serp_location" type="text" value="<?php echo htmlspecialchars($_POST['serp_location'] ?? $serpLocation, ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <label for="serp_timeout">Timeout für API-Anfragen (Sekunden)</label>
+        <input id="serp_timeout" name="serp_timeout" type="number" min="3" max="60" value="<?php echo htmlspecialchars((string)($_POST['serp_timeout'] ?? (string)$serpTimeout), ENT_QUOTES, 'UTF-8'); ?>" />
+
+        <p class="note">
+            Der Abruf der Google-Rankings erfolgt über den Drittanbieter <a href="https://serpapi.com/" target="_blank" rel="noopener">SerpAPI</a>.
+            Hinterlege hier einen gültigen API-Schlüssel, falls Rankings automatisch ermittelt werden sollen. Ohne Schlüssel bleibt
+            diese Funktion deaktiviert.
+        </p>
+
+        <div class="actions">
+            <button type="submit">Installation ausführen</button>
+        </div>
+
+        <p class="note">
+            Nach erfolgreicher Installation ist die Datei <code>install.php</code> nicht mehr erforderlich und kann entfernt oder
+            zusätzlich durch den Webserver geschützt werden.
+        </p>
+    </form>
+</div>
+</body>
+</html>

--- a/server/notifications.php
+++ b/server/notifications.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Determine if the provided snapshot should trigger notifications.
+ *
+ * @param array $summary Summary data extracted from the snapshot.
+ * @return bool
+ */
+function wp_monitor_should_notify(array $summary): bool
+{
+    if (! empty($summary['core_security_updates'])) {
+        return true;
+    }
+
+    $updateTotals = (
+        (int) ($summary['core_updates'] ?? 0) +
+        (int) ($summary['plugin_updates'] ?? 0) +
+        (int) ($summary['theme_updates'] ?? 0) +
+        (int) ($summary['translation_updates'] ?? 0)
+    );
+
+    if ($updateTotals > 0) {
+        return true;
+    }
+
+    if (! empty($summary['security_flags']) && in_array(false, $summary['security_flags'], true)) {
+        return true;
+    }
+
+    if (! empty($summary['pending_comments'])) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Send configured notifications for the provided snapshot summary.
+ *
+ * @param array $config  Global configuration.
+ * @param array $summary Snapshot summary.
+ * @return void
+ */
+function wp_monitor_dispatch_notifications(array $config, array $summary): void
+{
+    if (! wp_monitor_should_notify($summary)) {
+        return;
+    }
+
+    $notifications = $config['notifications'] ?? [];
+
+    if (! empty($notifications['email']['recipients'])) {
+        wp_monitor_send_email_notification($notifications['email'], $summary, $config);
+    }
+
+    if (! empty($notifications['slack']['webhook_url'])) {
+        wp_monitor_send_slack_notification($notifications['slack'], $summary, $config);
+    }
+}
+
+/**
+ * Compose a textual summary for notifications.
+ *
+ * @param array $summary Snapshot summary data.
+ * @return string
+ */
+function wp_monitor_render_notification_message(array $summary): string
+{
+    $lines   = [];
+    $lines[] = sprintf('Installation: %s', $summary['site_name'] ?: $summary['site_url']);
+    if (! empty($summary['site_group'])) {
+        $lines[] = sprintf('Gruppe: %s', $summary['site_group']);
+    }
+    $lines[] = sprintf('URL: %s', $summary['site_url']);
+    $lines[] = sprintf('Zeitpunkt: %s', $summary['checked_at']);
+
+    $lines[] = sprintf(
+        'Core Updates: %d (davon Sicherheitsupdates: %d)',
+        (int) $summary['core_updates'],
+        (int) $summary['core_security_updates']
+    );
+    $lines[] = sprintf('Plugin Updates: %d', (int) $summary['plugin_updates']);
+    $lines[] = sprintf('Theme Updates: %d', (int) $summary['theme_updates']);
+    $lines[] = sprintf('Übersetzungen: %d', (int) $summary['translation_updates']);
+    $lines[] = sprintf('Offene Kommentare: %d', (int) $summary['pending_comments']);
+    $lines[] = sprintf('Spam Kommentare: %d', (int) $summary['spam_comments']);
+
+    if (! empty($summary['security_flags'])) {
+        $lines[] = 'Sicherheitschecks:';
+        foreach ($summary['security_flags'] as $flag => $status) {
+            $lines[] = sprintf(' - %s: %s', $flag, $status ? 'OK' : 'Achtung');
+        }
+    }
+
+    if (! empty($summary['dashboard_url'])) {
+        $lines[] = 'Dashboard: ' . $summary['dashboard_url'];
+    }
+
+    return implode("\n", $lines);
+}
+
+/**
+ * Send an email notification using PHP's mail().
+ *
+ * @param array $emailConfig Email configuration.
+ * @param array $summary     Snapshot summary.
+ * @param array $config      Global configuration.
+ * @return void
+ */
+function wp_monitor_send_email_notification(array $emailConfig, array $summary, array $config): void
+{
+    $recipients = array_filter(array_map('trim', explode(',', (string) $emailConfig['recipients'])));
+    if (empty($recipients)) {
+        return;
+    }
+
+    $subject = $emailConfig['subject'] ?? 'WP Monitor Benachrichtigung';
+    $message = wp_monitor_render_notification_message($summary);
+
+    $headers = [];
+    if (! empty($emailConfig['from'])) {
+        $headers[] = 'From: ' . $emailConfig['from'];
+    }
+
+    foreach ($recipients as $recipient) {
+        @mail($recipient, $subject, $message, implode("\r\n", $headers));
+    }
+}
+
+/**
+ * Send a Slack notification through an incoming webhook.
+ *
+ * @param array $slackConfig Slack configuration.
+ * @param array $summary     Snapshot summary.
+ * @param array $config      Global configuration.
+ * @return void
+ */
+function wp_monitor_send_slack_notification(array $slackConfig, array $summary, array $config): void
+{
+    $webhook = trim((string) ($slackConfig['webhook_url'] ?? ''));
+    if ($webhook === '') {
+        return;
+    }
+
+    $payload = [
+        'text' => wp_monitor_render_notification_message($summary),
+    ];
+
+    $context = stream_context_create([
+        'http' => [
+            'method'  => 'POST',
+            'header'  => "Content-Type: application/json\r\n",
+            'content' => json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            'timeout' => 5,
+        ],
+    ]);
+
+    @file_get_contents($webhook, false, $context);
+}

--- a/server/plugin-download.php
+++ b/server/plugin-download.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/auth.php';
+
+$configFile = __DIR__ . '/config.php';
+if (! file_exists($configFile)) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'Server configuration missing.';
+    exit;
+}
+
+$config = require $configFile;
+
+wp_monitor_require_basic_auth($config, 'plain');
+
+$pluginDir = realpath(__DIR__ . '/../plugin/wp-monitor-client');
+if ($pluginDir === false || ! is_dir($pluginDir)) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'Plugin-Verzeichnis wurde nicht gefunden. Stelle sicher, dass "plugin/wp-monitor-client" vorhanden ist.';
+    exit;
+}
+
+if (! class_exists(ZipArchive::class)) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'Die PHP ZipArchive-Erweiterung ist nicht verfügbar.';
+    exit;
+}
+
+$tmpFile = tempnam(sys_get_temp_dir(), 'wpmc_');
+
+$zip = new ZipArchive();
+if ($zip->open($tmpFile, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'ZIP-Datei konnte nicht erstellt werden.';
+    @unlink($tmpFile);
+    exit;
+}
+
+$basePathLength = strlen($pluginDir);
+$rootFolder     = basename($pluginDir);
+
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($pluginDir, FilesystemIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::SELF_FIRST
+);
+
+foreach ($iterator as $fileInfo) {
+    /** @var SplFileInfo $fileInfo */
+    $relativePath = substr($fileInfo->getPathname(), $basePathLength + 1);
+    $localName    = $rootFolder . '/' . str_replace('\\', '/', $relativePath);
+
+    if ($fileInfo->isDir()) {
+        $zip->addEmptyDir($localName);
+    } else {
+        $zip->addFile($fileInfo->getPathname(), $localName);
+    }
+}
+
+$zip->close();
+
+header('Content-Type: application/zip');
+header('Content-Disposition: attachment; filename="wp-monitor-client.zip"');
+header('Content-Length: ' . filesize($tmpFile));
+
+$stream = fopen($tmpFile, 'rb');
+if ($stream !== false) {
+    fpassthru($stream);
+    fclose($stream);
+}
+
+@unlink($tmpFile);
+exit;


### PR DESCRIPTION
## Summary
- add an optional SerpAPI integration that fetches Google rankings for each monitored site and persists the results
- surface the best positions and keyword coverage in the dashboard overview and details, and extend the installer/configuration flows accordingly
- update the database schema, backup export, and documentation to capture the new ranking table and explain the optional feature

## Testing
- php -l server/api.php
- php -l server/dashboard.php
- php -l server/install.php
- php -l server/backup.php

------
https://chatgpt.com/codex/tasks/task_e_68e5005b853483339b8d3050ba2ab6c4